### PR TITLE
[bugfix] provide nilcheck in activity feed json serialization

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -279,9 +279,9 @@ class Person < ApplicationRecord
       version_id: version.id,
       id: version.item_id,
       timestamp: version.created_at,
-      changed_fields: version.changeset.keys,
+      changed_fields: version&.changeset&.keys,
       whodunnit: version.whodunnit,
-      name: version.item.name
+      name: version&.item&.name
     } if version
   end
 


### PR DESCRIPTION
* BUG: loading dashboard after destorying a Person flashes an error
* CAUSE: `version.item.name` throws b/c `item` is nil (not sure why!)
* FIX: use lonely operator to guard against nil values

This does not address the underlying problem, but provides a safe
patch for now.