### PR TITLE
resolve "login creator of subgroup after subgroup creation"

### DIFF
--- a/app/assets/stylesheets/create_group_form.scss
+++ b/app/assets/stylesheets/create_group_form.scss
@@ -12,12 +12,15 @@ $primaryblue: rgba(2, 117, 216, 1);
         }
     }
     // TODO: fix this!
-    /* .field_with_errors { */
-    /*     @extend .alert; */
-    /*     padding: inherit; */
-    /*     margin: 0; */
-    /*     background-color: red; */
-    /* } */
+    .field_with_errors {
+        @extend .alert;
+        padding: inherit;
+        margin: 0;
+        background-color: red;
+        input {
+            width: 100%;
+        }
+    }
     .form-container {
         display: flex;
         flex-direction: row;
@@ -61,7 +64,7 @@ $primaryblue: rgba(2, 117, 216, 1);
             .organizer-inputs {
                 display: flex;
                 flex-direction: column;
-                
+
             }
         }
         .submit {
@@ -74,4 +77,3 @@ $primaryblue: rgba(2, 117, 216, 1);
         }
     }
 }
-

--- a/app/controllers/subgroups_controller.rb
+++ b/app/controllers/subgroups_controller.rb
@@ -4,23 +4,18 @@ class SubgroupsController < ApplicationController
 
   # GET groups/:group_id/subgroups/new
   def new
-    @subgroup, @organizer = Group.build_group_and_organizer
+    @subgroup, foo = Group.build_group_with_organizer
   end
 
   # POST groups/:group_id/subgroups
   def create
-    @subgroup = @group.create_subgroup_with_organizer(
+    @subgroup, organizer = @group.create_subgroup_with_organizer(
       subgroup_attrs: subgroup_params,
       organizer_attrs: organizer_params
     )
-    if @subgroup&.valid? && @subgroup.affiliations_with&.last&.valid?
-      form = SignupForm.for(@subgroup)
-    end
-    if form&.valid?
-      redirect_to new_group_signup_form_signup_path(
-        group_id: @subgroup.id,
-        signup_form_id: form.id
-      )
+    if @subgroup.valid?
+      SignupForm.for(@subgroup)
+      sign_in_and_redirect(organizer)
     else
       render :new
     end

--- a/app/models/concerns/can_signup.rb
+++ b/app/models/concerns/can_signup.rb
@@ -21,12 +21,14 @@ module CanSignup
     end
 
     def create_from_signup(form, group, person_attrs)
-      group.members.new(person_attrs).tap do |member|
-        if member.save
-          group.memberships.create(:person => member, :role => 'member')
-          # group.signup.create(membership: membership, source: form)
-        end
-      end
+      Person.create(
+        person_attrs.merge(
+          memberships_attributes: [{ role: 'member', group: group }]
+          # TODO: (aguestuser|28-Feb-2018)
+          # to track signups, include nested attrs w/ something like:
+          # signup_attributes: { source: form }
+        )
+      )
     end
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -74,6 +74,7 @@ class Person < ApplicationRecord
   accepts_nested_attributes_for :memberships, reject_if: :all_blank, allow_destroy: true
   accepts_nested_attributes_for :personal_addresses, reject_if: :all_blank, allow_destroy: true
 
+  # TODO: (aguestuser|28-Feb-2018) fix `memership` typos
   has_many :organizer_memerships, -> { organizer }, :class_name => 'Membership'
   has_many :organized_groups, :source => :group, :through => :organizer_memerships
 

--- a/app/views/active_admin/devise/registrations/edit.html.erb
+++ b/app/views/active_admin/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="login-content pt-5">    
+<div class="login-content pt-5">
   <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>

--- a/app/views/subgroups/new.html.erb
+++ b/app/views/subgroups/new.html.erb
@@ -50,9 +50,14 @@
           <div class="organizer-input-container">
 
             <h2>Organizer Info</h2>
+
+            <% organizer = @subgroup.memberships.first.person %>
+            <% phone_number = organizer.phone_numbers.first %>
+            <% email_address = organizer.email_addresses.first %>
+            <% address = organizer.personal_addresses.first %>
             
             <div class="organizer-inputs">
-              <%= f.fields_for :organizer_attributes, @organizer do |member_form| %>
+              <%= f.fields_for :organizer_attributes, organizer do |member_form| %>
                 <div class="field">
                   <%= member_form.text_field :given_name, placeholder: :first_name %>
                 </div>
@@ -63,17 +68,17 @@
                   <%= member_form.password_field :password, placeholder: :password %>
                 </div>
                 <div class="field">
-                  <%= member_form.fields_for :phone_numbers_attributes do |phone_form| %>
+                  <%= member_form.fields_for :phone_numbers_attributes, phone_number do |phone_form| %>
                     <%= phone_form.text_field :number, placeholder: 'Phone number' %>  
                   <% end #member_form.fields_for :phone_number %>
                 </div>
                 <div class="field">
-                  <%= member_form.fields_for :email_addresses_attributes do |email_form| %>
+                  <%= member_form.fields_for :email_addresses_attributes, email_address do |email_form| %>
                     <%= email_form.text_field :address, placeholder: 'Email' %>
                   <% end #member_form.fields_for :email_address %>
                 </div>
                 <div class="field">
-                  <%= member_form.fields_for :personal_addresses_attributes do |email_form| %>
+                  <%= member_form.fields_for :personal_addresses_attributes, address do |email_form| %>
                     <%= email_form.text_field :postal_code, placeholder: 'Zipcode (personal)' %>
                   <% end #member_form.fields_for :email_address %>
                 </div>

--- a/test/feature/subgroup_creation_test.rb
+++ b/test/feature/subgroup_creation_test.rb
@@ -14,7 +14,7 @@ class SubgroupCreation < FeatureTest
 
     it "has fields for creating a group" do
       ['Name', 'Summary', 'Zipcode (group)'].each do |label|
-        page.find("#group-fields input[placeholder='#{label}']").wont_be_nil
+        page.find("input[placeholder='#{label}']").wont_be_nil
       end
     end
 
@@ -31,7 +31,7 @@ class SubgroupCreation < FeatureTest
         'Phone number',
         'Zipcode (personal)',
       ].each do |label|
-        page.find("#organizer-fields input[placeholder='#{label}']").wont_be_nil
+        page.find("input[placeholder='#{label}']").wont_be_nil
       end
     end
   end
@@ -76,10 +76,9 @@ class SubgroupCreation < FeatureTest
         end
       end
 
-      it "redirects to subgroup signup page" do
-        page.current_path.must_equal(
-          "/groups/#{Group.last.id}/signup_forms/#{SignupForm.last.id}/signups/new"
-        )
+      it "redirects to the user's profile page" do
+        page.current_path.must_equal "/profile"
+        page.must_have_content "Welcome"
       end
 
       it "saves group info" do

--- a/test/fixtures/people.yml
+++ b/test/fixtures/people.yml
@@ -99,8 +99,4 @@ new_signup:
     - Latin
   birthdate: 2011-09-17
   encrypted_password: $2a$11$08m64awvoVFg4sLOu.zA6e70E98bWC2VNewFWUNYjtnvutb/K68xK
-  custom_fields:
-    phone: iPhone
-  created_at: 2016-12-18 19:30:05
-  updated_at: 2016-12-18 19:30:05
   employer: Aspiration Tech

--- a/test/models/concerns/can_signup_test.rb
+++ b/test/models/concerns/can_signup_test.rb
@@ -40,9 +40,7 @@ class CanSignupTest < ActiveSupport::TestCase
       let(:new_member){ Person.last }
 
       before do
-        person_count
-        membership_count
-        contact_info_count
+        person_count; membership_count; contact_info_count
 
         Person.create_from_signup(form, group, person_attributes)
       end
@@ -51,8 +49,13 @@ class CanSignupTest < ActiveSupport::TestCase
         Person.count.must_equal person_count + 1
       end
 
-      it "creates a new membership" do
-        Membership.count.must_equal membership_count + 1
+      it "creates a new Membership" do
+        Membership.count.must_equal(membership_count + 1)
+      end
+
+      it "makes person a member of the group" do
+        group.memberships.last.person.must_equal new_member
+        new_member.memberships.last.group.must_equal group
       end
 
       it "saves the new member's contact info" do
@@ -64,8 +67,6 @@ class CanSignupTest < ActiveSupport::TestCase
           new_member.send(msg).first.primary?.must_equal true
         end
       end
-
-      
     end
 
     private

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -292,10 +292,11 @@ class GroupTest < ActiveSupport::TestCase
     let(:membership_count){ Membership.count }
     let(:email_count){ EmailAddress.count }
     let(:phone_count){ PhoneNumber.count }
+    let(:affiliation_count){ Affiliation.count }
 
     before do
-      person_count; email_count; phone_count; membership_count;
-      @subgroup = group.create_subgroup_with_organizer(
+      person_count; email_count; phone_count; membership_count; affiliation_count
+      @subgroup, @organizer = group.create_subgroup_with_organizer(
         subgroup_attrs:
           { name: "trystero", location_attributes: { postal_code: "90210" } },
         organizer_attrs:
@@ -307,8 +308,14 @@ class GroupTest < ActiveSupport::TestCase
     end
 
     describe "group is valid" do
-      it "returns the group" do
+      it "returns a valid group" do
+        @subgroup.must_be_instance_of Group
         @subgroup.valid?.must_equal true
+      end
+
+      it "returns a valid organizer" do
+        @organizer.must_be_instance_of Person
+        @organizer.valid?.must_equal true
       end
 
       it "creates a organizer for the group" do
@@ -321,7 +328,10 @@ class GroupTest < ActiveSupport::TestCase
         Group.last.members.last.must_equal Person.last
       end
 
-      focus
+      it "creates a new affiliation" do
+        Affiliation.count.must_equal(affiliation_count + 1)
+      end
+
       it "creates a new membership" do
         Membership.count.must_equal(membership_count + 1)
       end


### PR DESCRIPTION
this resolves #512 and fulfills its acceptance criteria

-------------


# notes:

* condense validation checks by using nested attrs
* redirect to profile page (not dashboard)

# side-effects:

* fix failing test for `Person.create_from_signup` (new memberhsip was
  not being crewated b/c fixture had invalid phone number -- FUN!!!)
* refactor `Person.create_from_signup` to use nested attrs
* fix bug causing nested field values to disappear on error
  re-render (caused by not derriving all `field_for` second arguments
  from the top level @subgroup instance variable -- YES it's weird we
  have to do this. i didn't make the rails rules, i just play by them)
* add red border styling to error messages