### PR TITLE
resolve "relax phone number validation

### DIFF
--- a/app/assets/stylesheets/create_group_form.scss
+++ b/app/assets/stylesheets/create_group_form.scss
@@ -40,7 +40,7 @@ $primaryblue: rgba(2, 117, 216, 1);
                 padding: .5em;
             }
             textarea {
-                min-height: 10em;
+                min-height: 13em;
             }
         }
         .group-input-container {

--- a/app/models/phone_number.rb
+++ b/app/models/phone_number.rb
@@ -20,13 +20,15 @@
 class PhoneNumber < ApplicationRecord
   include ArelHelpers::ArelTable
   belongs_to :person
-  PHONE_FORMAT = /\A(\((\d){3}\)\s|(\+1-)?(\d){3}-)(\d){3}-(\d){4}|(\d){10}\z/
+  PHONE_FORMAT = /\A(\+\d{1,2}[\s-]?)?\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}\z/
 
   validates :number, :presence => true,
             format: { with:  PHONE_FORMAT,
                       message: '%{value} is not a valid phone number' }
-
   validates_uniqueness_of :number, scope: :person_id
 
   scope :primary, -> { where(primary: true) }
+
+  # TODO: (aguestuser|28-Feb-2018)
+  # add before_create hook to impose standard formatting on phone numbers
 end

--- a/test/models/phone_number_test.rb
+++ b/test/models/phone_number_test.rb
@@ -1,27 +1,47 @@
 require 'test_helper'
 
 class PhoneNumberTest < ActiveSupport::TestCase
-  TEST_SAMPLES = {
-    "(123) 456-7890" => true,
-    "+1-123-456-7890" => true,
-    "123-456-7890" => true,
-    "123456-7890" => false,
-    "" => false,
-    "1212sdfsd2121" => false,
-    "(12)" => false,
-    "this is a #%(%& garbage string 31" => false,
-    "this is a garbage string 318" => false,
-    "1212/1212" => false
-  }
 
-  TEST_SAMPLES.each do |test_case, expectation|
-    test "on '#{test_case}'' should be #{expectation ? 'valid' : 'invalid'}" do
-      phone_number = PhoneNumber.new(:number => test_case)
-      if expectation 
-        assert phone_number.valid?
-      else
-        assert_not phone_number.valid?
-      end
+  VALID_PHONE_NUMBERS = [
+    "(734) 555 1212",
+    "(734) 555.1212",
+    "(734) 555-1212",
+    "(734) 5551212",
+    "(734)5551212",
+    "734 555 1212",
+    "734.555.1212",
+    "734-555-1212",
+    "7345551212",
+    "+1-123-456-7890",
+    "+1 123-456-7890",
+    "+43-123-456-7890",
+    "+43 123-456-7890",
+    "123456-7890",
+  ]
+
+  INVALID_PHONE_NUMBERS = [
+    "", # duh
+    "345551212", # too few characters
+    "(34) 555 1212", # that's not a real area code!
+    "734-555-1212 ext 2", # no alphabetic characters!
+    "7345551212!", # no special characters!
+    "+433 123-456-7890", # country codes only have 2 digits!
+    "1212sdfsd2121", # what did we say about alphabetic characters?
+    "(12)", # this is just weird
+    "this is a #%(%& garbage string 31", # this too
+    "this is a garbage string 318", # yup
+    "1212/1212", # i don't know why we even tested this one
+  ]
+
+  it "allows valid phone numbers" do
+    VALID_PHONE_NUMBERS.each do |number|
+      PhoneNumber.new.must have_valid(:number).when(number)
+    end
+  end
+
+  it "rejects invalid phone numbers" do
+    INVALID_PHONE_NUMBERS.each do |number|
+      PhoneNumber.new.wont have_valid(:number).when(number)
     end
   end
 


### PR DESCRIPTION
this resolves #511 and fulfills its ACs.
------------------------------------------------------

# Acceptance Testing Note

Here are some sample numbers:

## Valid Numbers

(734) 555 1212
(734) 555.1212
(734) 555-1212
(734) 5551212
(734)5551212
734 555 1212
734.555.1212
734-555-1212
7345551212
+1-123-456-7890
+1 123-456-7890
+43-123-456-7890
+43 123-456-7890
123456-7890

## Invalid Numbers

345551212
(34) 555 1212
734-555-1212 ext 2
7345551212!
+433 123-456-7890
1212sdfsd2121
(12)
this is a #%(%& garbage string 31
this is a garbage string 318
1212/1212

# side-effect:

make group creation form description textarea larger so it lines up with group fields (was supposed to happen in last PR)