### PR TITLE
partially resolve "feature toggle for events tab"

### DIFF
--- a/app/models/concerns/networkable.rb
+++ b/app/models/concerns/networkable.rb
@@ -6,9 +6,18 @@ module Networkable
     has_many :network_memberships
     has_many :networks, through: :network_memberships
 
+    # NESTED ATTRIBUTES
+    accepts_nested_attributes_for :network_memberships
+
     # ACCESSORS
     def primary_network
       network_memberships&.primary&.first&.network
+    end
+
+    def network_memberships_attributes
+      network_memberships.map do |nm|
+        nm.attributes.except('id', 'created_at', 'updated_at')
+      end
     end
   end
 end

--- a/app/models/concerns/networkable.rb
+++ b/app/models/concerns/networkable.rb
@@ -8,7 +8,7 @@ module Networkable
 
     # ACCESSORS
     def primary_network
-      network_memberships.primary.first.network
+      network_memberships&.primary&.first&.network
     end
   end
 end

--- a/app/models/concerns/networkable.rb
+++ b/app/models/concerns/networkable.rb
@@ -1,0 +1,14 @@
+module Networkable
+  extend ActiveSupport::Concern
+
+  included do
+    # ASSOCIATIONS
+    has_many :network_memberships
+    has_many :networks, through: :network_memberships
+
+    # ACCESSORS
+    def primary_network
+      network_memberships.primary.first.network
+    end
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,6 @@
 class Group < ApplicationRecord
   include ArelHelpers::ArelTable
+  include Networkable
   #has_paper_trail
   acts_as_taggable
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -157,9 +157,8 @@ class Group < ApplicationRecord
   def create_subgroup(subgroup_attrs)
     Group.create(
       subgroup_attrs.merge(
-        affiliations_with_attributes: [{
-          group: self
-        }]
+        affiliations_with_attributes: [{ group: self }],
+        network_memberships_attributes: network_memberships_attributes
       )
     )
   end

--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -5,4 +5,11 @@ class Network < ApplicationRecord
 
   # VALIDATIONS
   validates :name, uniqueness: true
+
+  validate :name_unchanged
+  def name_unchanged
+    if name_changed? && persisted?
+      errors.add(:name, "Changing a network's name is not permitted")
+    end
+  end
 end

--- a/app/models/network.rb
+++ b/app/models/network.rb
@@ -1,0 +1,8 @@
+class Network < ApplicationRecord
+  # ASSOCIATIONS
+  has_many :network_memberships
+  has_many :members, through: :network_memberships, source: 'group'
+
+  # VALIDATIONS
+  validates :name, uniqueness: true
+end

--- a/app/models/network_membership.rb
+++ b/app/models/network_membership.rb
@@ -7,13 +7,11 @@ class NetworkMembership < ApplicationRecord
   scope :primary, ->{ where(primary: true) }
 
   # VALIDATIONS
-  # TODO: index group_id:newtork_id (compound) if this is ever slow
   validates :group_id, uniqueness: {
               scope: :network_id,
               message: 'only one membership per network permitted'
             }
 
-  # TODO: index `primary`` if this is ever slow
   validates :primary, uniqueness: {
               scope: :group_id,
               message: 'only one primary network per group permitted'

--- a/app/models/network_membership.rb
+++ b/app/models/network_membership.rb
@@ -1,0 +1,21 @@
+class NetworkMembership < ApplicationRecord
+  # ASSOCIATIONS
+  belongs_to :group
+  belongs_to :network
+
+  # SCOPES
+  scope :primary, ->{ where(primary: true) }
+
+  # VALIDATIONS
+  # TODO: index group_id:newtork_id (compound) if this is ever slow
+  validates :group_id, uniqueness: {
+              scope: :network_id,
+              message: 'only one membership per network permitted'
+            }
+
+  # TODO: index `primary`` if this is ever slow
+  validates :primary, uniqueness: {
+              scope: :group_id,
+              message: 'only one primary network per group permitted'
+            }
+end

--- a/app/services/README.md
+++ b/app/services/README.md
@@ -8,27 +8,32 @@ The current implementation of feature toggles is given in `./feature_toggles.rb`
 
 2. we don't really have a good way of enumerating all of the subgroups of a group (if we follow all the affiliation edges in an affiliation graph via BFS or DFS we would discover nodes that are not necessarily subgroups of the group we started with. If we did something less fancy we would either loop for ever or not discover all children.)
 
-# Proposed Solution
 
-**1.** Create a `Network` class:
-* `Network` instances:
-  * have a `@name` field (which must be unique)
-  * `has_many :groups`
-  * `has_one :root_group`
-* `Group` instances:
-  * `belongs_to_one :network`
+# Status:
 
-**2.** Create a `networks.yml` config file, that enumerates:
-* keys that correspond to the names of the root group of a network (eg: `swing_left:`)
-* values that correspond to any attributes of the root group
-* Create a migration we run *every time** we add a root group that:
+* [x] **Implement`NetworkMembership`:**
+* add `Network` model, which  must have a unique name
+* groups can:
+  * be member of a network (via a `NetworkMembership`)
+  * have a primary network
+  * not have more than one primary network
+  * not become member of same network twice
+
+* [ ] **Modify `FeatureToggles::RULES`:**
+  * enumerate the names of networks for which a given feature is to be disabled (relying on the strong guarantee that networks must have unique names) --> inject `RULES` for now
+  * when calling `FeatureToggle.active?(:some_feather, group: some_group)`, inspect whether `some_group.primary_network.name` is included in the enumerated list of black listed network names to determine whether the toggle should be on or not
+
+* [ ] **Modify `create_subgroup`**
+  * when called (eg from the public subgroup creation form): add the subgroup to the parent group's `Network` (by assigning it the same `network_id` that its parent had
+
+* [ ] **Create a `networks.yml` config file that enumerates:**
+  * keys that correspond to the names of the root group of a network (eg: `swing_left:`)
+  * values that correspond to any attributes of the root group
+
+* [ ] **Create an `update_networks` migration that:**
+  * we run *every time** we add a root group
   * reads the attributes of all groups in `networks.yml`
   * uses `#find_or_create` to create new `Group` or `Network` instances that have been added to the `.yml file since the last migration
 
-**4.** Whenever the `create_subgroup` method is called (eg from the public subgroup creation form):
-  * add the subgroup to the parent group's `Network` (by assigning it the same `network_id` that its parent had**
-
-
-**5.** In `FeatureToggles::RULES`:**
-  * enumerate the names of networks for which a given feature is to be disabled (relying on the strong guarantee that networks must have unique names)
-  * when calling `FeatureToggle.active?(:some_feather, group: some_group)`, inspect whether `some_group.network.name` is included in the enumerated list of black listed network names to determine whether the toggle should be on or not
+* [ ] **rewrite tests for feature toggle:**
+  * always work based on configs (not injected rules)

--- a/app/services/README.md
+++ b/app/services/README.md
@@ -23,17 +23,16 @@ The current implementation of feature toggles is given in `./feature_toggles.rb`
   * enumerate the names of networks for which a given feature is to be disabled (relying on the strong guarantee that networks must have unique names) --> inject `RULES` for now
   * when calling `FeatureToggle.active?(:some_feather, group: some_group)`, inspect whether `some_group.primary_network.name` is included in the enumerated list of black listed network names to determine whether the toggle should be on or not
 
-* [ ] **Modify `create_subgroup`**
+* [x] **Modify `create_subgroup`**
   * when called (eg from the public subgroup creation form): add the subgroup to the parent group's `Network` (by assigning it the same `network_id` that its parent had
 
 * [ ] **Create a `networks.yml` config file that enumerates:**
   * keys that correspond to the names of the root group of a network (eg: `swing_left:`)
   * values that correspond to any attributes of the root group
 
+* [ ] **refactor feature toggle to always read from configs:**
+
 * [ ] **Create an `update_networks` migration that:**
   * we run *every time** we add a root group
   * reads the attributes of all groups in `networks.yml`
   * uses `#find_or_create` to create new `Group` or `Network` instances that have been added to the `.yml file since the last migration
-
-* [ ] **rewrite tests for feature toggle:**
-  * always work based on configs (not injected rules)

--- a/app/services/README.md
+++ b/app/services/README.md
@@ -1,0 +1,34 @@
+# Design Sketch for Networks for feature toggles
+
+The current implementation of feature toggles is given in `./feature_toggles.rb`. Its main purpose is (currently) to disable a given feature for groups and their subgroups.
+
+# Problems:
+
+1. looking up groups by name is yucky, but with multiple servers and growing list of customers we cannot know the id of a group in advance
+
+2. we don't really have a good way of enumerating all of the subgroups of a group (if we follow all the affiliation edges in an affiliation graph via BFS or DFS we would discover nodes that are not necessarily subgroups of the group we started with. If we did something less fancy we would either loop for ever or not discover all children.)
+
+# Proposed Solution
+
+**1.** Create a `Network` class:
+* `Network` instances:
+  * have a `@name` field (which must be unique)
+  * `has_many :groups`
+  * `has_one :root_group`
+* `Group` instances:
+  * `belongs_to_one :network`
+
+**2.** Create a `networks.yml` config file, that enumerates:
+* keys that correspond to the names of the root group of a network (eg: `swing_left:`)
+* values that correspond to any attributes of the root group
+* Create a migration we run *every time** we add a root group that:
+  * reads the attributes of all groups in `networks.yml`
+  * uses `#find_or_create` to create new `Group` or `Network` instances that have been added to the `.yml file since the last migration
+
+**4.** Whenever the `create_subgroup` method is called (eg from the public subgroup creation form):
+  * add the subgroup to the parent group's `Network` (by assigning it the same `network_id` that its parent had**
+
+
+**5.** In `FeatureToggles::RULES`:**
+  * enumerate the names of networks for which a given feature is to be disabled (relying on the strong guarantee that networks must have unique names)
+  * when calling `FeatureToggle.active?(:some_feather, group: some_group)`, inspect whether `some_group.network.name` is included in the enumerated list of black listed network names to determine whether the toggle should be on or not

--- a/app/services/README.md
+++ b/app/services/README.md
@@ -26,13 +26,19 @@ The current implementation of feature toggles is given in `./feature_toggles.rb`
 * [x] **Modify `create_subgroup`**
   * when called (eg from the public subgroup creation form): add the subgroup to the parent group's `Network` (by assigning it the same `network_id` that its parent had
 
-* [ ] **Create a `networks.yml` config file that enumerates:**
-  * keys that correspond to the names of the root group of a network (eg: `swing_left:`)
-  * values that correspond to any attributes of the root group
+* [x] **read networks from configs:**
+  * Create a `networks.yml` config file that enumerates:*
+    * keys that correspond to the names of the root group of a network (eg: `swing_left:`)
+    * values that correspond to any attributes of the root group
+  * populate `FeatureToggle::NETWORKS` from this config file
+  * alt config file for tests?
+  * maybe use configs to specify `FeatureToggle::RULES`
 
-* [ ] **refactor feature toggle to always read from configs:**
+* [ ] **use feature toggle for events**
+  * note: will only be able to verify this works in test env until next step
 
 * [ ] **Create an `update_networks` migration that:**
   * we run *every time** we add a root group
   * reads the attributes of all groups in `networks.yml`
   * uses `#find_or_create` to create new `Group` or `Network` instances that have been added to the `.yml file since the last migration
+  * fun migration & verify that feature toggle works for events in dev env

--- a/app/services/README.md
+++ b/app/services/README.md
@@ -35,10 +35,11 @@ The current implementation of feature toggles is given in `./feature_toggles.rb`
   * maybe use configs to specify `FeatureToggle::RULES`
 
 * [ ] **use feature toggle for events**
-  * note: will only be able to verify this works in test env until next step
+  * pass feature toggles to client via API calls (grr...)
+  * update dev data so we can see this working in browser
 
 * [ ] **Create an `update_networks` migration that:**
   * we run *every time** we add a root group
   * reads the attributes of all groups in `networks.yml`
   * uses `#find_or_create` to create new `Group` or `Network` instances that have been added to the `.yml file since the last migration
-  * fun migration & verify that feature toggle works for events in dev env
+  * fun migration & verify that feature toggle works for events in dev env w/o using add-hoc data added in last step (ie: after db:reset)

--- a/app/services/README.md
+++ b/app/services/README.md
@@ -19,7 +19,7 @@ The current implementation of feature toggles is given in `./feature_toggles.rb`
   * not have more than one primary network
   * not become member of same network twice
 
-* [ ] **Modify `FeatureToggles::RULES`:**
+* [x] **Modify `FeatureToggles::RULES`:**
   * enumerate the names of networks for which a given feature is to be disabled (relying on the strong guarantee that networks must have unique names) --> inject `RULES` for now
   * when calling `FeatureToggle.active?(:some_feather, group: some_group)`, inspect whether `some_group.primary_network.name` is included in the enumerated list of black listed network names to determine whether the toggle should be on or not
 

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -11,16 +11,15 @@ class FeatureToggle
   class << self
     # (symbol, symbol) => boolean
     def active?(feature, group: nil)
-      active_for_group?(feature, group)
+      !disable_for_group?(feature, group)
     end
   end
 
   private
 
   class << self
-    def active_for_group?(feature, group)
-      !group ||
-        !RULES.dig(:events, :disable_for, :groups)&.include?(group.name)
+    def disable_for_group?(feature, group)
+      RULES.dig(feature, :disable_for, :groups)&.include?(group.name) if group
     end
   end
 end

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -4,25 +4,11 @@ class FeatureToggle
     Rails.configuration.networks
   ).freeze
 
-  RULES = {
-    events: {
-      disable_for: {
-        networks: Set.new([
-          NETWORKS.dig(:swing_left, :name)
-        ])
-      }
-    },
-    google_groups: {
-      enable_for: {
-        networks: Set.new([
-          NETWORKS.dig(:swing_left, :name)
-        ])
-      }
-    }
-  }.freeze
+  RULES = HashWithIndifferentAccess.new(
+    Rails.configuration.feature_toggles
+  ).freeze
 
   class << self
-    # (symbol, symbol) => boolean
     def on?(feature, group = nil)
       return enable_for_group?(feature, group) if is_opt_in?(feature)
       return !disable_for_group?(feature, group) if is_opt_out?(feature)

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -3,9 +3,7 @@ class FeatureToggle
   RULES = {
     events: {
       disable_for: {
-        groups: Set.new(
-          "Swing Left"
-        )
+        groups: Set.new(["Swing Left"])
       }
     }
   }.freeze

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -1,0 +1,28 @@
+class FeatureToggle
+
+  RULES = {
+    events: {
+      disable_for: {
+        groups: Set.new(
+          "Swing Left"
+        )
+      }
+    }
+  }.freeze
+
+  class << self
+    # (symbol, symbol) => boolean
+    def active?(feature, group: nil)
+      active_for_group?(feature, group)
+    end
+  end
+
+  private
+
+  class << self
+    def active_for_group?(feature, group)
+      !group ||
+        !RULES.dig(:events, :disable_for, :groups)&.include?(group.name)
+    end
+  end
+end

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -1,9 +1,7 @@
 class FeatureToggle
 
-  # TODO (aguestuser|21 Mar 2018)
-  # eventually read these from Rails.configuration.networks
   NETWORKS = HashWithIndifferentAccess.new(
-    swing_left: { name: 'Swing Left Network' }
+    Rails.configuration.networks
   ).freeze
 
   RULES = {

--- a/app/services/feature_toggle.rb
+++ b/app/services/feature_toggle.rb
@@ -1,25 +1,59 @@
 class FeatureToggle
 
+  # TODO (aguestuser|21 Mar 2018)
+  # eventually read these from Rails.configuration.networks
+  NETWORKS = HashWithIndifferentAccess.new(
+    swing_left: { name: 'Swing Left Network' }
+  ).freeze
+
   RULES = {
     events: {
       disable_for: {
-        groups: Set.new(["Swing Left"])
+        networks: Set.new([
+          NETWORKS.dig(:swing_left, :name)
+        ])
+      }
+    },
+    google_groups: {
+      enable_for: {
+        networks: Set.new([
+          NETWORKS.dig(:swing_left, :name)
+        ])
       }
     }
   }.freeze
 
   class << self
     # (symbol, symbol) => boolean
-    def active?(feature, group: nil)
-      !disable_for_group?(feature, group)
+    def on?(feature, group = nil)
+      return enable_for_group?(feature, group) if is_opt_in?(feature)
+      return !disable_for_group?(feature, group) if is_opt_out?(feature)
+      true
     end
   end
 
   private
 
   class << self
+
+    def is_opt_in?(feature)
+      RULES.dig(feature, :enable_for)
+    end
+
+    def is_opt_out?(feature)
+      RULES.dig(feature, :disable_for)
+    end
+
+    def enable_for_group?(feature, group)
+      apply_rule(feature, :enable_for, group&.primary_network)
+    end
+
     def disable_for_group?(feature, group)
-      RULES.dig(feature, :disable_for, :groups)&.include?(group.name) if group
+      apply_rule(feature, :disable_for, group&.primary_network)
+    end
+
+    def apply_rule(feature, rule, network)
+      RULES.dig(feature, rule, :networks)&.include?(network&.name) || false
     end
   end
 end

--- a/client/app/bundles/Events/components/Nav.jsx
+++ b/client/app/bundles/Events/components/Nav.jsx
@@ -41,6 +41,7 @@ class Nav extends Component {
                 path={membersPath()}
                 active={activeTab === 'members'}
               />
+              {/* TODO: pick up on feature toggle here, disable if off */}
               <NavItem
                 title='Events'
                 path={eventsPath()}
@@ -67,6 +68,7 @@ class Nav extends Component {
                 active={activeTab === 'members'}
               />
 
+              {/* TODO: pick up on feature toggle here, disable if off */}
               <NavItem
                 title={`${this.isRootNav() ? 'All' : ''} Events`}
                 path={eventsPath()}

--- a/client/app/bundles/Events/containers/Dashboard.jsx
+++ b/client/app/bundles/Events/containers/Dashboard.jsx
@@ -20,6 +20,17 @@ class Dashboard extends Component {
   componentWillMount() {
     const { groupId } = this.props.match.params;
     this.props.fetchGroup(groupId);
+    // 
+    // TODO: set feature toggles here, by doing either:
+    // (1) fetch all feature toggle rules *once* when app loads;
+    //     access them here via selector
+    // (2) fetch granular feature toggles for group by accessing `FeatureToggle.on?`
+    //     via new `FeatureToggleController`
+    // 
+    // TRADEOFF:
+    // (1) more (possibly irrelevant) state held in memory in browser
+    //  vs.
+    // (2) more network calls
   }
 
   renderTextEditor () {
@@ -47,6 +58,7 @@ class Dashboard extends Component {
         <Breadcrumbs active='Dashboard' location={this.props.location} />
         <br />
 
+        {/* TODO: this is where you would inject feature toggles into Nav */}
         <Nav activeTab='dashboard' />
         <br />
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,5 +19,6 @@ module AdvocacyCommons
 
     # custom config yml
     config.networks = config_for(:networks)
+    config.feature_toggles = config_for(:feature_toggles)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,8 @@ module AdvocacyCommons
 
     config.eager_load_paths << Rails.root.join('lib')
     config.active_job.queue_adapter = :resque
+
+    # custom config yml
+    config.networks = config_for(:networks)
   end
 end

--- a/config/feature_toggles.yml
+++ b/config/feature_toggles.yml
@@ -1,0 +1,22 @@
+# NOTE:
+# names given for networks must match
+# names given in `config/networks.yml`
+
+default: &default
+  events:
+    disable_for:
+      networks:
+        - 'Swing Left Network'
+  google_groups:
+    enable_for:
+      networks:
+        - 'Swing Left Network'
+
+development:
+  <<: *default
+
+production:
+  <<: *default
+
+test:
+  <<: *default

--- a/config/networks.yml
+++ b/config/networks.yml
@@ -1,0 +1,21 @@
+default: &default
+  swing_left:
+    name: 'Swing Left Network'
+    groups:
+     - name: 'Swing Left'
+
+development:
+  <<: *default
+
+production:
+  <<: *default
+
+test:
+  swing_left:
+    name: 'Swing Left Network'
+    groups:
+     - name: 'Swing Left'
+  the_avengers:
+    name: 'The Avengers'
+    groups:
+      - name: 'Fantastic Four'

--- a/db/migrate/20180320172047_create_network.rb
+++ b/db/migrate/20180320172047_create_network.rb
@@ -1,0 +1,7 @@
+class CreateNetwork < ActiveRecord::Migration[5.0]
+  def change
+    create_table :networks do |t|
+      t.string :name
+    end
+  end
+end

--- a/db/migrate/20180320182830_create_network_memberships.rb
+++ b/db/migrate/20180320182830_create_network_memberships.rb
@@ -1,8 +1,8 @@
 class CreateNetworkMemberships < ActiveRecord::Migration[5.0]
   def change
     create_table :network_memberships do |t|
-      t.references :network, foregin_key: true
-      t.references :group, foregin_key: true
+      t.references :network, foreign_key: true
+      t.references :group, foreign_key: true
       t.boolean :primary
 
       t.timestamps

--- a/db/migrate/20180320182830_create_network_memberships.rb
+++ b/db/migrate/20180320182830_create_network_memberships.rb
@@ -1,0 +1,11 @@
+class CreateNetworkMemberships < ActiveRecord::Migration[5.0]
+  def change
+    create_table :network_memberships do |t|
+      t.references :network, foregin_key: true
+      t.references :group, foregin_key: true
+      t.boolean :primary
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180321021928_add_indexes_to_network_memberships.rb
+++ b/db/migrate/20180321021928_add_indexes_to_network_memberships.rb
@@ -1,0 +1,7 @@
+class AddIndexesToNetworkMemberships < ActiveRecord::Migration[5.0]
+  def change
+    add_index :network_memberships, [:group_id, :network_id], unique: true
+    add_index :network_memberships, [:network_id, :group_id], unique: true
+    add_index :network_memberships, :primary
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -929,6 +929,8 @@ ActiveRecord::Schema.define(version: 20180321021928) do
   add_foreign_key "group_signup_forms", "groups"
   add_foreign_key "memberships", "groups"
   add_foreign_key "memberships", "people"
+  add_foreign_key "network_memberships", "groups"
+  add_foreign_key "network_memberships", "networks"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_grants", "people", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180131182107) do
+ActiveRecord::Schema.define(version: 20180320182830) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -425,6 +425,20 @@ ActiveRecord::Schema.define(version: 20180131182107) do
     t.index ["group_id"], name: "index_memberships_on_group_id", using: :btree
     t.index ["person_id", "group_id"], name: "index_memberships_on_person_id_and_group_id", unique: true, using: :btree
     t.index ["person_id"], name: "index_memberships_on_person_id", using: :btree
+  end
+
+  create_table "network_memberships", force: :cascade do |t|
+    t.integer  "network_id"
+    t.integer  "group_id"
+    t.boolean  "primary"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["group_id"], name: "index_network_memberships_on_group_id", using: :btree
+    t.index ["network_id"], name: "index_network_memberships_on_network_id", using: :btree
+  end
+
+  create_table "networks", force: :cascade do |t|
+    t.string "name"
   end
 
   create_table "notes", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180320182830) do
+ActiveRecord::Schema.define(version: 20180321021928) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -433,8 +433,11 @@ ActiveRecord::Schema.define(version: 20180320182830) do
     t.boolean  "primary"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["group_id", "network_id"], name: "index_network_memberships_on_group_id_and_network_id", unique: true, using: :btree
     t.index ["group_id"], name: "index_network_memberships_on_group_id", using: :btree
+    t.index ["network_id", "group_id"], name: "index_network_memberships_on_network_id_and_group_id", unique: true, using: :btree
     t.index ["network_id"], name: "index_network_memberships_on_network_id", using: :btree
+    t.index ["primary"], name: "index_network_memberships_on_primary", using: :btree
   end
 
   create_table "networks", force: :cascade do |t|

--- a/test/fixtures/addresses.yml
+++ b/test/fixtures/addresses.yml
@@ -79,6 +79,11 @@ new_signup:
   occupation: busker
   person: new_signup
 
+group_location:
+  type: GroupAddress
+  region: MA
+  postal_code: 02138
+
 subgroup_location:
   type: GroupAddress
   region: NY

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -59,3 +59,15 @@ swing_left:
   description: "sweet chariot!"
   location: group_location
   an_api_key: 'test-token-8'
+
+swing_left_ohio:
+  origin_system: "Affinity"
+  name: "Swing Left Ohio"
+  location: subgroup_location
+  an_api_key: 'test-token-9'
+
+swing_left_new_york:
+  origin_system: "Affinity"
+  name: "Swing Left New York"
+  location: subgroup_location
+  an_api_key: 'test-token-10'

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -52,3 +52,10 @@ subgroup:
   description: "<div>We have a really big balloon and we're flying it into WWI</div>"
   location: subgroup_location
   an_api_key: 'test-token-7'
+
+swing_left:
+  origin_system: "Affinity"
+  name: "Swing Left"
+  description: "sweet chariot!"
+  location: group_location
+  an_api_key: 'test-token-8'

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -71,3 +71,15 @@ swing_left_new_york:
   name: "Swing Left New York"
   location: subgroup_location
   an_api_key: 'test-token-10'
+
+fantastic_four:
+  origin_system: "Affinity"
+  name: "The Fantastic Four"
+  location: subgroup_location
+  an_api_key: 'test-token-11'
+
+my_local_political_club:
+  origin_system: "Affinity"
+  name: "My Local Political Club"
+  location: subgroup_location
+  an_api_key: 'test-token-12'

--- a/test/fixtures/network_memberships.yml
+++ b/test/fixtures/network_memberships.yml
@@ -1,0 +1,13 @@
+swing_left_ohio_membership:
+  group: swing_left_ohio
+  network: swing_left_network
+  primary: true
+
+swing_left_ohio_avengers_membership:
+  group: swing_left_ohio
+  network: the_avengers
+
+swing_left_new_york_membership:
+  group: swing_left_new_york
+  network: swing_left_network
+  primary: true

--- a/test/fixtures/network_memberships.yml
+++ b/test/fixtures/network_memberships.yml
@@ -11,3 +11,13 @@ swing_left_new_york_membership:
   group: swing_left_new_york
   network: swing_left_network
   primary: true
+
+fantastic_four_avengers_membership:
+  group: fantastic_four
+  network: the_avengers
+  primary: true
+
+my_local_political_club_swing_left_membership:
+  group: my_local_club
+  network: swing_left_network
+  primary: false

--- a/test/fixtures/networks.yml
+++ b/test/fixtures/networks.yml
@@ -1,0 +1,5 @@
+swing_left_network:
+  name: Swing Left Network
+
+the_avengers:
+  name: The Avengers

--- a/test/models/concerns/networkable_test.rb
+++ b/test/models/concerns/networkable_test.rb
@@ -1,0 +1,23 @@
+require_relative "../../test_helper"
+
+class NetworkableTest < ActiveSupport::TestCase
+  let(:swing_left_ohio){ groups(:swing_left_ohio) }
+  let(:swing_left){ networks(:swing_left_network) }
+  let(:the_avengers){ networks(:the_avengers) }
+
+  describe "associations" do
+    specify { swing_left_ohio.networks.first.must_be_kind_of Network }
+  end
+
+  describe "accessors" do
+
+    it "retrieves networks" do
+      swing_left_ohio.networks.
+        must_equal [ swing_left, the_avengers ]
+    end
+
+    it "retrieves a primary network" do
+      swing_left_ohio.primary_network.must_equal swing_left
+    end
+  end
+end

--- a/test/models/concerns/networkable_test.rb
+++ b/test/models/concerns/networkable_test.rb
@@ -20,4 +20,19 @@ class NetworkableTest < ActiveSupport::TestCase
       swing_left_ohio.primary_network.must_equal swing_left
     end
   end
+
+  describe "nested attributes" do
+    it "accepts nested attributes for network membership" do
+      assert_difference "NetworkMembership.count", 1 do
+        Group.create(
+          name: 'foogroup',
+          network_memberships_attributes: [
+            {
+              network: networks(:the_avengers),
+            }
+          ]
+        )
+      end
+    end
+  end
 end

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -241,11 +241,14 @@ class GroupTest < ActiveSupport::TestCase
     let(:group_count){ Group.count }
     let(:address_count){ Address.count }
     let(:affiliation_count){ Affiliation.count }
-
-    before do
+    let(:count_all){
       group_count
       address_count
       affiliation_count
+    }
+
+    before do
+      count_all
       @subgroup = group.create_subgroup(
         name: "trystero",
         location_attributes: {
@@ -286,6 +289,24 @@ class GroupTest < ActiveSupport::TestCase
         subgroup.valid?.must_equal false
       end
     end
+
+
+    describe "network membership cloning" do
+
+      describe "group has no networks" do
+        it "assigns no network memberships" do
+          @subgroup.networks.must_be_empty
+        end
+      end
+
+      describe "group has primary network" do
+        let(:group){ groups(:swing_left_ohio) }
+
+        it "assings subgroup primary membership in network" do
+          @subgroup.primary_network.must_equal networks(:swing_left_network)
+        end
+      end
+    end
   end
 
   describe "#create_subgroup_with_organizer" do
@@ -295,9 +316,16 @@ class GroupTest < ActiveSupport::TestCase
     let(:email_count){ EmailAddress.count }
     let(:phone_count){ PhoneNumber.count }
     let(:affiliation_count){ Affiliation.count }
+    let(:count_all){
+      person_count
+      email_count
+      phone_count
+      membership_count
+      affiliation_count
+    }
 
     before do
-      person_count; email_count; phone_count; membership_count; affiliation_count
+      count_all
       @subgroup, @organizer = group.create_subgroup_with_organizer(
         subgroup_attrs:
           { name: "trystero", location_attributes: { postal_code: "90210" } },
@@ -345,6 +373,10 @@ class GroupTest < ActiveSupport::TestCase
       it "creates phone number for organizer" do
         PhoneNumber.count.must_equal(phone_count + 1)
       end
+    end
+
+    describe "group has primary network" do
+      it ""
     end
 
     describe "group is not valid" do

--- a/test/models/network_membership_test.rb
+++ b/test/models/network_membership_test.rb
@@ -1,0 +1,31 @@
+require_relative '../test_helper'
+
+class NetworkMembershipTest < ActiveSupport::TestCase
+  let(:membership){ network_memberships(:swing_left_ohio_membership) }
+
+  describe "associations" do
+    specify { membership.group.must_be_instance_of Group }
+    specify { membership.network.must_be_instance_of Network }
+  end
+
+  describe "validations" do
+    let(:swing_left_new_york){ groups(:swing_left_new_york) }
+    let(:swing_left){ networks(:swing_left_network) }
+    let(:the_avengers){ networks(:the_avengers) }
+
+    it "forbids duplicate memberships" do
+      refute NetworkMembership.new(
+        group: swing_left_new_york,
+        network: swing_left
+      ).valid?
+    end
+
+    it "forbids more than one primary membership" do
+      refute NetworkMembership.new(
+        group: swing_left_new_york,
+        network: the_avengers,
+        primary: true
+      ).valid?
+    end
+  end
+end

--- a/test/models/network_test.rb
+++ b/test/models/network_test.rb
@@ -1,0 +1,15 @@
+require_relative '../test_helper'
+
+class NetworkTest < ActiveSupport::TestCase
+  let(:network){ networks(:swing_left_network) }
+
+  describe "associations"do
+    specify { network.members.first.must_be_instance_of Group }
+  end
+
+  describe "validations" do
+    it "forbids dupe names" do
+      refute Network.new(name: network.name).valid?
+    end
+  end
+end

--- a/test/models/network_test.rb
+++ b/test/models/network_test.rb
@@ -11,5 +11,10 @@ class NetworkTest < ActiveSupport::TestCase
     it "forbids dupe names" do
       refute Network.new(name: network.name).valid?
     end
+
+    it "forbids changing name from original value" do
+      network.assign_attributes(name: "new name")
+      refute network.valid?
+    end
   end
 end

--- a/test/services/feature_toggle_test.rb
+++ b/test/services/feature_toggle_test.rb
@@ -2,23 +2,58 @@ require_relative "../test_helper"
 
 class FeatureToggleTest < ActiveSupport::TestCase
 
-  let(:swing_left){ groups(:swing_left) }
-
   it "enables a feature that has no rules" do
-    FeatureToggle.active?(:foobar).
+    FeatureToggle.on?(:foobar).
       must_equal true
   end
 
-  it "enables a feature for group that has not been black-listed" do
-    FeatureToggle.active?(:events, group: groups(:one)).
-      must_equal true
+  describe "an opt-out feature" do
+    it "is enabled for a group without a network" do
+      FeatureToggle.on?(:events, groups(:one)).
+        must_equal true
+    end
+
+    it "is enabled for a group whose primary network has not opted out" do
+      FeatureToggle.on?(:events, groups(:fantastic_four)).
+        must_equal true
+    end
+
+    it "is enabled for a group whose secondary network has opted out" do
+      # my local political club is member of swing left
+      # which is not its primary network
+      FeatureToggle.on?(:events, groups(:my_local_political_club)).
+        must_equal true
+    end
+
+    it "is disabled for groups whose primary network has opted out" do
+      networks(:swing_left_network).members.each do |group|
+        FeatureToggle.on?(:events, group).
+          must_equal false
+      end
+    end
   end
 
-  it "disables a feature for a black-listed group" do
-    FeatureToggle.active?(:events, group: swing_left).
-      must_equal false
-  end
+  describe "an opt-in feature" do
+    it "is disabled for a group without a network" do
+      FeatureToggle.on?(:google_groups, groups(:one)).
+        must_equal false
+    end
 
-  # Hmmm....
-  it "disables a feature for all subgroups of a black-listed group"
+    it "is disabled for a group whose primary network has not opted in" do
+      FeatureToggle.on?(:google_groups, groups(:fantastic_four)).
+        must_equal false
+    end
+
+    it "is disabled for a group whose secondary vnetwork has opted in" do
+      FeatureToggle.on?(:google_groups, groups(:my_local_political_club)).
+        must_equal false
+    end
+
+    it "is enabled for groups whose primary network has opted in" do
+      networks(:swing_left_network).members.each do |group|
+        FeatureToggle.on?(:google_groups, group).
+          must_equal true
+      end
+    end
+  end
 end

--- a/test/services/feature_toggle_test.rb
+++ b/test/services/feature_toggle_test.rb
@@ -1,0 +1,24 @@
+require_relative "../test_helper"
+
+class FeatureToggleTest < ActiveSupport::TestCase
+
+  let(:swing_left){ groups(:swing_left) }
+
+  it "enables a feature that has no rules" do
+    FeatureToggle.active?(:foobar).
+      must_equal true
+  end
+
+  it "enables a feature for group that has not been black-listed" do
+    FeatureToggle.active?(:events, group: groups(:one)).
+      must_equal true
+  end
+
+  it "disables a feature for a black-listed group" do
+    FeatureToggle.active?(:events, group: swing_left).
+      must_equal false
+  end
+
+  # Hmmm....
+  it "disables a feature for all subgroups of a black-listed group"
+end


### PR DESCRIPTION
This partially completes #523 

# What is done

* [x] **Implement`NetworkMembership`:**
* add `Network` model, which  must have a unique name
* groups can:
  * be member of a network (via a `NetworkMembership`)
  * have a primary network
  * not have more than one primary network
  * not become member of same network twice

* [x] **Provide `FeatureToggle.on?``:**
  * enumerate the names of networks for which a given feature is to be disabled or enabled (relying on the strong guarantee that networks must have unique, immutable names)
  * when calling `FeatureToggle.on?(:some_feather, some_group)`, inspect whether `some_group.primary_network.name` is included in the enumerated list of black- or white-listed network names to determine whether the toggle should be on or off
  * note: `some_group` can always be ascertained by calling `current_group`

* [x] **Modify `create_subgroup`**
  * when called (eg from the public subgroup creation form): add the subgroup to the parent group's `Network` (by assigning it the same `network_id` that its parent had

* [x] **read networks from configs:**
  * Create a `networks.yml` config file that enumerates:*
    * keys that correspond to the names of the root group of a network (eg: `swing_left:`)
    * values that correspond to any attributes of the root group
  * populate `FeatureToggle::NETWORKS` from this config file

# What is not done

* [ ] **use feature toggle for events**
  * pass feature toggles to client via API calls (grr...)
  * update dev data so we can see this working in browser

* [ ] **Create an `update_networks` migration that:**
  * we run *every time** we add a root group
  * reads the attributes of all groups in `networks.yml`
  * uses `#find_or_create` to create new `Group` or `Network` instances that have been added to the `.yml file since the last migration
  * fun migration & verify that feature toggle works for events in dev env w/o using add-hoc data added in last step (ie: after db:reset)
