### PR TITLE
[nostory] fix heroku migration bug

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
+release: rake db:migrate
 web: rails s -p 3000
 client: sh -c 'rm app/assets/webpack/* || true && cd client && bundle exec rake react_on_rails:locale && yarn run build:development'
 resque: env TERM_CHILD=1 bundle exec rake resque:work


### PR DESCRIPTION
* BUG: app fails in production after PRs that introduce migrations
* CAUSE: heroku does not run migrations without `release` task
  specifying to do so
* FIX: add a `release` task to run migrations