### PR TITLE
resolve "add required fields to subgroup creation page"

### DIFF
--- a/app/views/subgroups/new.html.erb
+++ b/app/views/subgroups/new.html.erb
@@ -20,7 +20,6 @@
           <% end # if @subgroup.errors %>
         </div>
       </div>
-
       
       <%= form_for @subgroup, url: {action: "create"} do |f| %>
         <div class="form-container">
@@ -31,7 +30,7 @@
             <div class="group-inputs">
 
               <div class="field">
-                <%= f.text_field :name, placeholder: :name %>
+                <%= f.text_field :name, placeholder: :name, required: true %>
               </div>
               <div class="field">
                 <%= f.fields_for :location, @subgroup.location do |location_form| %>
@@ -39,7 +38,7 @@
                 <% end %>
               </div>
               <div class="field">
-                <%= f.text_area :description, placeholder: :description %>
+                <%= f.text_area :description, placeholder: 'Description (may contain HTML)' %>
               </div>
             </div>
           </div>
@@ -55,25 +54,34 @@
             
             <div class="organizer-inputs">
               <%= f.fields_for :organizer_attributes, organizer do |member_form| %>
+                <!-- email -->
                 <div class="field">
-                  <%= member_form.text_field :given_name, placeholder: :first_name %>
+                  <%= member_form.fields_for :email_addresses_attributes, email_address do |email_form| %>
+                    <%= email_form.text_field :address, placeholder: 'Email', required: true %>
+                  <% end #member_form.fields_for :email_address %>
+                </div>
+
+                <!-- password -->
+                <div class="field">
+                  <%= member_form.password_field :password, placeholder: :password, required: true %>
+                </div>
+
+                <!-- name -->
+                <div class="field">
+                  <%= member_form.text_field :given_name, placeholder: :first_name, required: true %>
                 </div>
                 <div class="field">
-                  <%= member_form.text_field :family_name, placeholder: :last_name %>
+                  <%= member_form.text_field :family_name, placeholder: :last_name, required: true %>
                 </div>
-                <div class="field">
-                  <%= member_form.password_field :password, placeholder: :password %>
-                </div>
+
+                <!-- phone -->
                 <div class="field">
                   <%= member_form.fields_for :phone_numbers_attributes, phone_number do |phone_form| %>
                     <%= phone_form.text_field :number, placeholder: 'Phone number' %>  
                   <% end #member_form.fields_for :phone_number %>
                 </div>
-                <div class="field">
-                  <%= member_form.fields_for :email_addresses_attributes, email_address do |email_form| %>
-                    <%= email_form.text_field :address, placeholder: 'Email' %>
-                  <% end #member_form.fields_for :email_address %>
-                </div>
+
+                <!-- zip -->
                 <div class="field">
                   <%= member_form.fields_for :personal_addresses_attributes, address do |email_form| %>
                     <%= email_form.text_field :postal_code, placeholder: 'Zipcode (personal)' %>

--- a/test/feature/subgroup_creation_test.rb
+++ b/test/feature/subgroup_creation_test.rb
@@ -19,8 +19,14 @@ class SubgroupCreation < FeatureTest
       end
     end
 
-    it "has a large description text area" do
-      page.find("textarea[placeholder='Description']").wont_be_nil
+    it "has a large description text area for group" do
+      page.find(
+        "textarea[placeholder='Description (may contain HTML)']"
+      ).wont_be_nil
+    end
+
+    it "has correct required group fields" do
+      page.find("input[placeholder='Name'][required='required']").wont_be_nil
     end
 
     it "has groups for creating an organizer" do
@@ -33,6 +39,12 @@ class SubgroupCreation < FeatureTest
         'Zipcode (personal)',
       ].each do |label|
         page.find("input[placeholder='#{label}']").wont_be_nil
+      end
+    end
+
+    it "has correct required organizer fields" do
+      ['Email', 'Password', 'First Name', 'Last Name'].each do |label|
+        "input[placeholder='#{label}'][required='required']"
       end
     end
   end
@@ -55,7 +67,7 @@ class SubgroupCreation < FeatureTest
         perform_enqueued_jobs do
           fill_out_form(
             'Name' => 'Jawbreaker',
-            'Description' => 'I want to be a boat, I want to learn to swim',
+            'Description (may contain HTML)' => 'I want to be a boat, I want to learn to swim',
             'Zipcode (group)' => '90210',
             'First name' => 'herbert',
             'Last name' => 'stencil',


### PR DESCRIPTION
# Notes

* resolves #507 and #542 
* require group name, organizer email/password/first name/last name
* list email & password first for consistency

# Screenshots

![required-fields](https://user-images.githubusercontent.com/6032844/37990009-ff1af610-31d2-11e8-8b06-e3b49cb5582a.png)


