### PR TITLE
resolve  "align columns with headers on members list page"

### DIFF
--- a/client/app/bundles/Events/components/Member.jsx
+++ b/client/app/bundles/Events/components/Member.jsx
@@ -132,9 +132,7 @@ class Member extends Component {
           {this.renderNameLink()}
           <td>{member['primary-phone-number']}</td>
           <td>{this.localityAndRegion()}</td>
-          {isAllowed(['member'], currentRole)
-            ? <td/>
-            : <td>{this.groupColumn()}</td>}
+          {isAllowed(['member'], currentRole) && this.groupColumn()}
           {this.showTags()}
           <td>{role}</td>
           <td>

--- a/client/app/bundles/Events/components/MembersTable.jsx
+++ b/client/app/bundles/Events/components/MembersTable.jsx
@@ -108,9 +108,7 @@ class MembersTable extends Component {
             {this.nameColumn()}
             {this.phoneColumn()}
             {this.locationColumn()}
-            {isAllowed(['member', 'volunteer'], currentRole)
-              ? <th/>
-              : this.groupColumn() }
+            {isAllowed(['member', 'volunteer'], currentRole) && this.groupColumn() }
             {this.showTags()}
             <SortableHeader title='Role' sortBy='role' style={{ width: '15%'}} />
             <th style={{ width: '5%'}}></th>


### PR DESCRIPTION
# Notes

This resolves #548 and fulfills its acceptance criteria.

* BUG: in member lists for groups that are leaves in affiliation trees (but not for root-node groups -- ie: parent groups), the column contents are shifted one column to the right from the headers (starting at the "tags" column)
* CAUSE: at such levels, business logic dictates that we hide the  group name, which we were seeking to accomplish by rendering empty `<th>` and `<td>` tags for columns and cells (respectively). styling was causing the `<td>` tags to collapse, but not the `<th>` tags.
* FIX: instead of reasoning about widths, if we are supposed to hide the group column, just don't render `<th>` or `<td>` tags at all. problem solved.

# Screenshots

**before**

![member-list-failure-mode](https://user-images.githubusercontent.com/6032844/37996844-180f3e7e-31e7-11e8-8e0b-4ae1b6159f9a.png)


**after**

![members-list-success-mode](https://user-images.githubusercontent.com/6032844/37996851-1d71b856-31e7-11e8-8248-7f254a2f8870.png)
