### PR TITLE
[#548] fix undefined location values bug

### DIFF
--- a/client/app/bundles/Events/components/Group.jsx
+++ b/client/app/bundles/Events/components/Group.jsx
@@ -9,8 +9,10 @@ class Group extends Component {
   showAddress() {
     const { location } = this.props.group.attributes;
     if (location) {
-      const {locality, region, postal_code} = location;
-      return `${locality}, ${region} ${postal_code}`
+      return ['locality', 'region', 'postal_code']
+        .map(attr => location[attr])
+        .filter(Boolean) // filter falsey values
+        .join(", ");
     }
   }
 


### PR DESCRIPTION
# Notes

this resolves #513 and fulfills its AC's by doing the following:

* supress undefined city/state/zip values when any are not present
* show all city/state/zip values when any are present

# Bug description

* BUG: when a group has a zipcode but no city or state, the groups
  table displays "undefined" for the latter two values
* CAUSE: lack of proper null-filtering
* FIX: provide proper null-filtering

# Screenshots:

**before:**

![location-failure-mode](https://user-images.githubusercontent.com/6032844/37998795-1c1718a0-31ee-11e8-9b4b-f36bf8fd50fd.png)


**after:**

![location-success-mode](https://user-images.githubusercontent.com/6032844/37998806-23f0a51e-31ee-11e8-8472-5d9ee62d10a1.png)
