### PR TITLE
[#552] clicking all mailto links now opens new tab

### DIFF
--- a/client/app/bundles/Events/components/Attendance.jsx
+++ b/client/app/bundles/Events/components/Attendance.jsx
@@ -19,7 +19,8 @@ class Attendance extends Component {
     const email = this.props.member['primary-email-address']
 
     if (email)
-      return <a href={`mailto:${email}`} className='fa fa-envelope-o'/>
+      return <a href={`mailto:${email}`} className='fa fa-envelope-o'
+                target="_blank"/>
   }
 
   renderFacebookLink() {

--- a/client/app/bundles/Events/components/EmailLink.jsx
+++ b/client/app/bundles/Events/components/EmailLink.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 const EmailLink = ({ email, style }) => {
   if (email)
-    return <a href={`mailto:${email}`} style={style} className='fa fa-envelope-o'/>
+    return <a href={`mailto:${email}`} style={style} className='fa fa-envelope-o'
+              target="_blank" />
 
   return null;
 }

--- a/client/app/bundles/Events/components/Member.jsx
+++ b/client/app/bundles/Events/components/Member.jsx
@@ -12,7 +12,8 @@ class Member extends Component {
     const email = this.props.member['primary-email-address']
 
     if (email)
-      return <a href={`mailto:${email}`} className='fa fa-envelope-o'/>
+      return <a href={`mailto:${email}`} className='fa fa-envelope-o'
+                target="_blank"/>
   }
 
   localityAndRegion() {

--- a/client/app/bundles/Events/components/MembersTable.jsx
+++ b/client/app/bundles/Events/components/MembersTable.jsx
@@ -34,7 +34,8 @@ class MembersTable extends Component {
     const { emails } = this.state;
     if (emails.length)
       return (
-        <a href={`mailto:${emails.join(',')}`} className='fa fa-envelope-o'/>
+        <a href={`mailto:${emails.join(',')}`} className='fa fa-envelope-o'
+           target="_blank" />
       );
     else
       return (<i className='fa fa-envelope-o'/>);

--- a/client/app/bundles/Events/containers/EventDetail.jsx
+++ b/client/app/bundles/Events/containers/EventDetail.jsx
@@ -49,7 +49,8 @@ class EventDetail extends Component {
     return(
       <div>
         <span> Event Organizer: </span>
-        <a href={`mailto:${attributes['primary-email-address']}`}>
+        <a href={`mailto:${attributes['primary-email-address']}`}
+           target="_blank" >
           {`${attributes['given-name']} ${attributes['family-name']}`}
         </a>
       </div>

--- a/client/app/bundles/Events/containers/MemberDetail.jsx
+++ b/client/app/bundles/Events/containers/MemberDetail.jsx
@@ -140,7 +140,8 @@ class MemberDetail extends Component {
 
           <span>
             Email:&nbsp;
-            <a href={`mailto:${attributes['primary-email-address']}`}>
+            <a href={`mailto:${attributes['primary-email-address']}`}
+               target="_blank">
               {attributes['primary-email-address']}
             </a>
           </span>


### PR DESCRIPTION
# Notes

This resolves #552 

* if i have gmail set as my default mail client (:sob: ), then clicking mailto links will open in a new tab, not replace the app

# Screenshot

**clicking:**

![mailto-click](https://user-images.githubusercontent.com/6032844/37999572-7b3d81c2-31f1-11e8-85dd-63900fc21b79.png)

**new tab:**

![mailto-success-mode](https://user-images.githubusercontent.com/6032844/37999642-c84334d0-31f1-11e8-9f95-bef3bf3b6fd7.png)
