### PR TITLE
[bug] fix destroy dependency btw/ group & custom from

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -35,6 +35,8 @@ class Group < ApplicationRecord
   has_and_belongs_to_many :petitions
   has_and_belongs_to_many :share_pages
   has_and_belongs_to_many :forms
+  has_many :custom_forms, foreign_key: :group_id, dependent: :destroy
+
   belongs_to :creator, class_name: "Person"
   belongs_to :modified_by, class_name: "Person"
   belongs_to :location, class_name: 'GroupAddress', foreign_key: :address_id


### PR DESCRIPTION
* BUG: active record throws error when deleting a group that has a custom form
* CAUSE: we violate a foreign key constraint that by not deleting the custom form when we delete the group
* FIX: add a `dependent: :destroy` helper to delete associated custom forms when we delete a group