### PR TITLE
resolve "link to signup page from group dashboard"

### DIFF
--- a/app/models/custom_form.rb
+++ b/app/models/custom_form.rb
@@ -24,7 +24,13 @@ class CustomForm < ApplicationRecord
 
   belongs_to :form
   accepts_nested_attributes_for :form
-  delegate :description, :title, :name, :call_to_action, :submit_text, to: :form
+  delegate :browser_url,
+           :call_to_action,
+           :name,
+           :submit_text,
+           :title,
+           :description,
+           to: :form
 
   belongs_to :group
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -146,7 +146,7 @@ class Group < ApplicationRecord
 
   def affiliates_with_role(person, role)
     affiliates.joins(:memberships)
-              .where('person_id = ? and role = ?', peuprson.id, role).take
+              .where('person_id = ? and role = ?', person.id, role).take
   end
 
   def affiliation_with_role(person, role)

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -36,6 +36,7 @@ class Group < ApplicationRecord
   has_and_belongs_to_many :share_pages
   has_and_belongs_to_many :forms
   has_many :custom_forms, foreign_key: :group_id, dependent: :destroy
+  has_many :signup_forms, foreign_key: :group_id, class_name: 'SignupForm', dependent: :destroy
 
   belongs_to :creator, class_name: "Person"
   belongs_to :modified_by, class_name: "Person"
@@ -145,7 +146,7 @@ class Group < ApplicationRecord
 
   def affiliates_with_role(person, role)
     affiliates.joins(:memberships)
-              .where('person_id = ? and role = ?', person.id, role).take
+              .where('person_id = ? and role = ?', peuprson.id, role).take
   end
 
   def affiliation_with_role(person, role)
@@ -181,5 +182,10 @@ class Group < ApplicationRecord
     slugified_group_name = name.downcase.split.join('-')
     email_base = primary_network&.google_gsuite_email_base
     "#{slugified_group_name}#{email_base}"
+  end
+
+  # ACCESSORS
+  def signup_url
+    signup_forms.first.browser_url
   end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -186,6 +186,6 @@ class Group < ApplicationRecord
 
   # ACCESSORS
   def signup_url
-    signup_forms.first.browser_url
+    signup_forms&.first&.browser_url
   end
 end

--- a/app/models/signup_form.rb
+++ b/app/models/signup_form.rb
@@ -12,6 +12,17 @@ class SignupForm < CustomForm
   # VALIDATIONS
   validates_presence_of :group_id
 
+  # LIFE CYCLE HOOKS
+
+  after_create :save_browser_url
+  def save_browser_url
+    form.update(
+      browser_url: Rails.application.routes.url_helpers.
+        new_group_signup_form_signup_url(group_id, self.id)
+    )
+  end
+
+  # FACTORIES
   def self.for(group)
     SignupForm.create!(
       group: group,

--- a/app/representers/json_api/group_representer.rb
+++ b/app/representers/json_api/group_representer.rb
@@ -10,6 +10,7 @@ class JsonApi::GroupRepresenter < Roar::Decorator
     property :origin_system
     property :browser_url
     property :featured_image_url
+    property :signup_url
 
     property :creator, extend: JsonApi::PeopleRepresenter, class: Person
   end

--- a/client/app/bundles/Events/components/GroupResources.jsx
+++ b/client/app/bundles/Events/components/GroupResources.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const GroupResources = ({signupUrl}) => (
+  <div>
+    <h4>Resources:</h4>
+    <ul>
+      <li>
+        <a href={signupUrl}>Signup Page</a>
+      </li>
+    </ul>
+  </div>
+);
+
+export default GroupResources;

--- a/client/app/bundles/Events/containers/Dashboard.jsx
+++ b/client/app/bundles/Events/containers/Dashboard.jsx
@@ -10,6 +10,7 @@ import PersonActivityFeed from '../components/PersonActivityFeed';
 import SyncActivityFeed from '../components/SyncActivityFeed';
 import { fetchGroup, fetchFeatureToggles, addAlert } from '../actions';
 import UserAuth from '../components/UserAuth';
+import GroupResources from '../components/GroupResources';
 import { client, dashboardPath } from '../utils';
 
 class Dashboard extends Component {
@@ -37,7 +38,7 @@ class Dashboard extends Component {
   }
 
   render() {
-    const { group: { attributes}, featureToggles } = this.props;
+    const { group: { attributes }, featureToggles } = this.props;
     const { events, attendances, people, sync, editText } = this.state;
 
     if(!attributes) { return null }
@@ -52,6 +53,8 @@ class Dashboard extends Component {
         <br />
 
         {this.renderTextEditor()}
+        <hr/>
+        <GroupResources {...{ signupUrl: attributes['signup-url'] } } />
         <hr/>
 
         <div className="edit-button">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,10 +48,13 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
+  hostname = ENV['HOSTNAME'] || 'localhost'
+  Rails.application.routes.default_url_options = { host: hostname, port: 3000 }
+
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.perform_caching = false
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.default_url_options = { host: hostname, port: 3000 }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     :port           => ENV['MAILGUN_SMTP_PORT'],

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -99,6 +99,8 @@ Rails.application.configure do
   # as per: http://www.chrisjmendez.com/2016/12/19/how-to-get-your-web-url-from-heroku-dynamically/
 
   hostname = ENV['HOSTNAME'] || "#{ENV['HEROKU_APP_NAME']}.herokuapp.com"
+  Rails.application.routes.default_url_options = { host: hostname, port: 3000 }
+
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.default_url_options = { host: hostname }
   config.action_mailer.smtp_settings = {

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,6 +25,10 @@ Rails.application.configure do
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 
+  # Set a default URL from env
+  hostname = ENV['HOSTNAME'] || 'localhost'
+  Rails.application.routes.default_url_options = { host: hostname, port: 3000 }
+
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
   config.action_mailer.perform_caching = false

--- a/test/controllers/api/v1/people_controller_test.rb
+++ b/test/controllers/api/v1/people_controller_test.rb
@@ -52,7 +52,7 @@ class Api::V1::PeopleControllerTest < ActionController::TestCase
       assert_equal 2, json['page'], 'page'
 
       links = json['_links']
-      assert_equal 'http://test.host/api/v1/people', links['self']['href'], 'self link'
+      assert_equal 'http://test.host:3000/api/v1/people', links['self']['href'], 'self link'
       assert_equal '/api/v1/people?page=1', links['previous']['href'], 'previous link'
       assert_equal '/api/v1/people?page=3', links['next']['href'], 'next link'
     end

--- a/test/fixtures/custom_forms.yml
+++ b/test/fixtures/custom_forms.yml
@@ -8,3 +8,8 @@ group_signup:
   group_id: 1
   form: group_signup
   # has_many :form_input_groups
+
+fantastic_four_signup:
+  type: SignupForm
+  group: fantastic_four
+  form: fantastic_four_signup

--- a/test/fixtures/forms.yml
+++ b/test/fixtures/forms.yml
@@ -49,3 +49,13 @@ group_signup:
   total_submissions: 0
   person_id: 1 # `person: one` would be better!
   creator_id: 1 # `creator: one` would be better!
+
+fantastic_four_signup:
+  origin_system: "Affinity"
+  name: "fantastic_four_signup_form"
+  title: "Come fight SHIELD!"
+  description: "We offer great benefits"
+  summary: MyString
+  call_to_action: "join our group!"
+  submit_text: 'Submit'
+  browser_url: 'http://localhost:3000/groups/1036040811/signup_forms/350404309/signups/new'

--- a/test/models/custom_form_test.rb
+++ b/test/models/custom_form_test.rb
@@ -64,10 +64,6 @@ class CustomFormTest < ActiveSupport::TestCase
     end
   end
 
-
-
-
-
   describe "validations" do
 
     let(:custom_form){ CustomForm.new }
@@ -132,9 +128,15 @@ class CustomFormTest < ActiveSupport::TestCase
   end
 
   describe "accessors" do
-
     it "delegates to nested form accessors" do
-      [:description, :title, :name, :call_to_action, :submit_text].each do |method|
+      [
+        :browser_url,
+        :call_to_action,
+        :description,
+        :name,
+        :submit_text,
+        :title,
+      ].each do |method|
         custom_form.send(method).must_equal custom_form.form.send(method)
       end
     end

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../test_helper'
 
 class GroupTest < ActiveSupport::TestCase
   test "basic person associations" do
@@ -220,6 +220,15 @@ class GroupTest < ActiveSupport::TestCase
     assert group.affiliation_with_role(person, volunteer_role), group
     assert group_fourth.affiliation_with_role(person_admin, volunteer_role), group
 
+  end
+
+  describe "accessors" do
+    #TODO: (aguestuser) move some of above tests into this bracket
+    it "returns the group's sigup page url" do
+      groups(:fantastic_four)
+        .signup_url
+        .must_equal forms(:fantastic_four_signup).browser_url
+    end
   end
 
   describe "nested attributes" do

--- a/test/models/signup_form_test.rb
+++ b/test/models/signup_form_test.rb
@@ -12,7 +12,6 @@ class SignupFormTest < ActiveSupport::TestCase
   end
 
   describe "validations" do
-
     let(:signup_form) { SignupForm.new }
 
     it "requries a group id" do
@@ -21,8 +20,17 @@ class SignupFormTest < ActiveSupport::TestCase
     end
   end
 
-  describe "factories" do
+  describe "lifecycle hooks" do
+    it "saves `form.browser_url` after creation" do
+      f= SignupForm.for(group)
+      f.form
+        .browser_url
+        .must_equal "http://localhost:3000/groups/#{group.id}" +
+                    "/signup_forms/#{f.id}/signups/new"
+    end
+  end
 
+  describe "factories" do
     it "creates a default form for a group" do
       f = SignupForm.for(group)
 


### PR DESCRIPTION
resolves #554 

# Summary

* create a new "Resources" section on the Group dashboard
* link to the signup page in it

# Implementation Notes

* store the signup url according to OSDI schema (ie: as a `browser_url` on a `form` entity)
* encapsulate retrieval of url with `Group#signup_url`
* add `signup_url` to `Group` Roar representer
* add `GroupResources` component, use it to display link

# Screenshots

hovering over signup pae link (see url bottom-left):

![signup-page-link-hover](https://user-images.githubusercontent.com/6032844/38342071-07f4dd82-384a-11e8-8b2f-e52b92374387.png)

slicking on singup page link:

![signup-page-click-thru](https://user-images.githubusercontent.com/6032844/38342084-198cd5b8-384a-11e8-801b-22ad3c19f14d.png)



