### PR TITLE
cleanup 'resolve "link to signup page from group dashboard"'

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -186,6 +186,12 @@ class Group < ApplicationRecord
 
   # ACCESSORS
   def signup_url
-    signup_forms&.first&.browser_url
+    has_signup_form? &&
+      Rails.application.routes.url_helpers.
+        new_group_signup_form_signup_url(self, signup_forms.first)
+  end
+
+  def has_signup_form?
+    !signup_forms.empty?
   end
 end

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -1,9 +1,5 @@
 namespace :heroku do
   task postdeploy: :environment do
-
-    # TODO (05 Apr 2018): remove this after deploying PR #600
-    Migration.backfill_signup_urls
-
     if ENV["HEROKU_APP_NAME"]&.include? "dev"
       logger = Logger.new(STDOUT)
 

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -223,11 +223,12 @@ class GroupTest < ActiveSupport::TestCase
   end
 
   describe "accessors" do
-    #TODO: (aguestuser) move some of above tests into this bracket
-    it "returns the group's sigup page url" do
+      it "returns the group's signup page url" do
       groups(:fantastic_four)
         .signup_url
-        .must_equal forms(:fantastic_four_signup).browser_url
+        .must_equal 'http://localhost:3000' +
+                    '/groups/1036040811' +
+                    '/signup_forms/350404309/signups/new'
     end
   end
 


### PR DESCRIPTION
this provides a cleanup to #600 and thus actually resolves #554 

# Notes

this is a pretty weedy fix intended to prevent confusing discrepancies between review apps and dev or staging and prod from arising during the review process.

if you care to read the gory details... we use derrived values for the signup_url display link in group dashboard (instead of the value persisted in `group.signup_forms.first.browser_url`):

* turns out this is less complicated b/c staging apps & dev share a db, so if we use the persisted url as the display value, then dev will always show (dead) links that include the hostname for (deleted) review apps as the base of the url
* to eliminate confusion in the review process, just use a derrived value, which will always know the correct hostname and thus never
produce incorrect urls
* for convenience, we keep the `after_create` hooks that persisted `form.browser_urls` since they provide future compatibility with OSDI and it would take more time to rip them out than leave them in now
