### PR TITLE
[#568] Use "Whiteboard" in text-editor edit mode

### DIFF
--- a/client/app/bundles/Events/components/TextEditor.jsx
+++ b/client/app/bundles/Events/components/TextEditor.jsx
@@ -172,7 +172,7 @@ class TextEditor extends Component {
       <div className='col-md-12'>
         <div className="row">
           <div className="col-md-3">
-              <h4>Aditional Description</h4>
+              <h4>Whiteboard</h4>
           </div>
           <div className='col-md-4'>
             <button


### PR DESCRIPTION
Fixes bugs found by @Matt-Holland in #596 
and thus resolves #568 

# Screenshot

![whiteboard-everywhere](https://user-images.githubusercontent.com/6032844/38387535-14d37666-38e6-11e8-895d-fbccf53f8485.png)
