### PR TITLE
resolve "revise signup form fields"

### DIFF
--- a/app/models/address_input_group.rb
+++ b/app/models/address_input_group.rb
@@ -17,6 +17,7 @@ class AddressInputGroup < FormInputGroup
     address_lines: 'address',
     locality: 'city',
     region: 'state',
+    postal_code: 'zip code',
   ).freeze
 
 end

--- a/app/models/custom_form.rb
+++ b/app/models/custom_form.rb
@@ -14,8 +14,8 @@ class CustomForm < ApplicationRecord
 
   NESTED_INPUT_GROUPS = [
     :email_input_group,
-    :phone_input_group,
     :address_input_group,
+    :phone_input_group,
   ]
 
   INPUT_GROUPS = [:person_input_group] + NESTED_INPUT_GROUPS

--- a/app/models/form_input_group.rb
+++ b/app/models/form_input_group.rb
@@ -108,5 +108,11 @@ class FormInputGroup < ApplicationRecord
     self.class::VALID_INPUTS & inputs
   end
 
+  def label_for(input)
+    self.class.label_for(input) + (required?(input) ? "*" : "")
+  end
 
+  def required?(input)
+    required.include? input
+  end
 end

--- a/app/models/signup_form.rb
+++ b/app/models/signup_form.rb
@@ -13,7 +13,6 @@ class SignupForm < CustomForm
   validates_presence_of :group_id
 
   # LIFE CYCLE HOOKS
-
   after_create :save_browser_url
   def save_browser_url
     form.update(
@@ -33,15 +32,20 @@ class SignupForm < CustomForm
         call_to_action: "get involved"
       ),
       person_input_group: PersonInputGroup.new(
-        inputs: %w[given_name family_name]
+        inputs: %w[given_name family_name],
+        required: %w[given_name family_name]
       ),
       email_input_group: EmailInputGroup.new(
-        inputs: %w[address]
+        inputs: %w[address],
+        required: %w[address]
       ),
       address_input_group: AddressInputGroup.new(
-        inputs: %w[postal_code]
+        inputs: %w[postal_code],
+        required: %w[postal_code]
       ),
-      phone_input_group: PhoneInputGroup.new
+      phone_input_group: PhoneInputGroup.new(
+        inputs: %w[number]
+      )
     )
   end
 end

--- a/app/services/migration.rb
+++ b/app/services/migration.rb
@@ -54,5 +54,14 @@ class Migration
         end
       end
     end
+
+    def backfill_signup_form_fields
+      SignupForm.all.each do |sf|
+        sf.person_input_group&.update!(required: %w[given_name family_name])
+        sf.email_input_group&.update!(required: %w[address])
+        sf.address_input_group&.update!(required: %w[postal_code])
+        sf.phone_input_group&.update!(inputs: %w[number], required: [])
+      end
+    end
   end
 end

--- a/app/services/migration.rb
+++ b/app/services/migration.rb
@@ -54,12 +54,5 @@ class Migration
         end
       end
     end
-
-    def backfill_signup_urls
-      Group
-        .all
-        .select{ |g| g.signup_forms.first.present? && g.signup_url.nil? }
-        .each { |g| g.signup_forms.first.save_browser_url }
-    end
   end
 end

--- a/app/views/signups/new.html.erb
+++ b/app/views/signups/new.html.erb
@@ -26,7 +26,10 @@
 
           <% @form.person_input_group.inputs.each do |input| %>
             <div class="entry">
-              <%= f.text_field input, placeholder: PersonInputGroup.label_for(input) %>
+              <%= f.text_field input,
+                  placeholder: @form.person_input_group.label_for(input),
+                  required: @form.person_input_group.required?(input)
+              %>
             </div>
           <% end # @form.person_input_groups.each do |input| %>
 
@@ -34,7 +37,10 @@
             <%= f.fields_for input_group.resource do |ff| %>
               <% input_group.inputs.each do |input| %>
                 <div class="entry">
-                  <%= ff.text_field input, placeholder: input_group.class.label_for(input) %>
+                  <%= ff.text_field input,
+                      placeholder: input_group.label_for(input),
+                      required: input_group.required?(input)
+                  %>
                 </div>
               <% end # each |input| %>
             <% end # f.fields_for input_group.resource do |ff|  %>

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -1,5 +1,9 @@
 namespace :heroku do
   task postdeploy: :environment do
+
+    # TODO: delete this after #521 is deployed
+    Migration.backfill_signup_form_fields
+
     if ENV["HEROKU_APP_NAME"]&.include? "dev"
       logger = Logger.new(STDOUT)
 

--- a/test/feature/signup_test.rb
+++ b/test/feature/signup_test.rb
@@ -29,7 +29,7 @@ class Signup < FeatureTest
           ig = form.send(input_group)
           page
             .find(input_selector_for(ig, input))['placeholder']
-            .must_equal(ig.class.label_for(input))
+            .must_equal(ig.label_for(input))
         end
       end
     end
@@ -100,7 +100,7 @@ class Signup < FeatureTest
 
       it "shows an error for invalid postal code" do
         page.must_have_content(
-          "Postal code invalid is not a valid postal code"
+          "Zip code invalid is not a valid postal code"
         )
       end
 

--- a/test/models/concerns/can_signup_test.rb
+++ b/test/models/concerns/can_signup_test.rb
@@ -25,8 +25,8 @@ class CanSignupTest < ActiveSupport::TestCase
     it "provides a list of associated resources required by a form" do
       person.signup_resources_for(form)
         .must_equal([person.email_addresses,
-                     person.phone_numbers,
-                     person.personal_addresses])
+                     person.personal_addresses,
+                     person.phone_numbers])
     end
   end
 

--- a/test/models/custom_form_test.rb
+++ b/test/models/custom_form_test.rb
@@ -144,8 +144,8 @@ class CustomFormTest < ActiveSupport::TestCase
     it "provides a list of input groups for nested attributes" do
       custom_form.nested_input_groups
         .must_equal([custom_form.email_input_group,
-                     custom_form.phone_input_group,
-                     custom_form.address_input_group])
+                     custom_form.address_input_group,
+                     custom_form.phone_input_group])
     end
   end
 end

--- a/test/models/form_input_group_test.rb
+++ b/test/models/form_input_group_test.rb
@@ -23,20 +23,18 @@ class FormInputGroupTest < ActiveSupport::TestCase
 
   let(:input_group){ form_input_groups(:abstract) }
 
-  specify "inheritance" do
-    input_group.must_be_instance_of FakeInputGroup
-    input_group.must_be_kind_of FormInputGroup
+  describe "inheritance" do
+    specify { input_group.must_be_instance_of FakeInputGroup }
+    specify { input_group.must_be_kind_of FormInputGroup }
   end
 
   describe "associations" do
-
     it "belongs to a custom form" do
       input_group.custom_form.must_be_kind_of CustomForm
     end
   end
 
   describe "attributes" do
-
     it "has an array of available inputs" do
       input_group.inputs.must_be_kind_of Array
     end
@@ -51,7 +49,6 @@ class FormInputGroupTest < ActiveSupport::TestCase
   end
 
   describe "interface" do
-
     it "has nil RESOURCE" do
       FormInputGroup::RESOURCE.must_be_nil
     end
@@ -69,7 +66,6 @@ class FormInputGroupTest < ActiveSupport::TestCase
     end
 
     describe "a concrete instance" do
-
       it "provides a message for accessing nested resources" do
         input_group.resource.must_equal :fakes
       end
@@ -113,10 +109,30 @@ class FormInputGroupTest < ActiveSupport::TestCase
   end
 
   describe "accessors" do
-
     it "provides a sorted list of inputs" do
       input_group.inputs = FakeInputGroup::VALID_INPUTS.dup.reverse
       input_group.sorted_inputs.must_equal FakeInputGroup::VALID_INPUTS
+    end
+
+    it "provides a label for a required field" do
+      input_group.label_for(input_group.inputs.second)
+        .must_equal "Barrr*"
+    end
+
+    it "provides a label for an optional field" do
+      input_group.label_for(input_group.inputs.first)
+        .must_equal "Proper Foo"
+    end
+  end
+
+  describe "predicates" do
+
+    it "reports that a field is required" do
+      input_group.required?(input_group.inputs.second).must_equal true
+    end
+
+    it "reports that a field is not required" do
+      input_group.required?(input_group.inputs.first).must_equal false
     end
   end
 end

--- a/test/models/signup_form_test.rb
+++ b/test/models/signup_form_test.rb
@@ -31,26 +31,43 @@ class SignupFormTest < ActiveSupport::TestCase
   end
 
   describe "factories" do
-    it "creates a default form for a group" do
-      f = SignupForm.for(group)
+    describe ".for" do
+      let(:f){ SignupForm.for group }
 
-      f.group.must_equal(group)
+      specify { f.group.must_equal(group) }
+      specify { f.name.must_equal "#{group.name}_default_signup_form" }
+      specify { f.title.must_equal group.name }
+      specify { f.description.must_equal group.description }
+      specify { f.call_to_action.must_equal "get involved" }
 
-      f.name.must_equal "#{group.name}_default_signup_form"
-      f.title.must_equal group.name
-      f.description.must_equal group.description
-      f.call_to_action.must_equal "get involved"
+      it 'includes correct person fields' do
+        f.person_input_group.inputs
+          .must_equal %w[given_name family_name]
+      end
 
-      f.person_input_group.inputs.must_equal(
-        %w[given_name family_name]
-      )
-      f.email_input_group.inputs.must_equal(
-        %w[address]
-      )
-      f.address_input_group.inputs.must_equal(
-        %w[postal_code]
-      )
-      f.phone_input_group.inputs.must_equal []
+      it 'requires correct person fields' do
+        f.person_input_group.required
+          .must_equal %w[given_name family_name]
+      end
+
+      it 'includes correct email fields' do
+        f.email_input_group.inputs
+          .must_equal %w[address]
+      end
+
+      it 'requires correct address fields' do
+        f.address_input_group.required
+          .must_equal %w[postal_code]
+      end
+
+      it 'includes correct phone fields' do
+        f.phone_input_group.inputs
+          .must_equal %w[number]
+      end
+
+      it 'requires no phone fields' do
+        f.phone_input_group.required.must_be_empty
+      end
     end
   end
 end

--- a/test/services/migration_test.rb
+++ b/test/services/migration_test.rb
@@ -149,19 +149,4 @@ class MigrationTest < ActiveSupport::TestCase
       end
     end
   end
-
-  describe ".backfill_signup_urls" do
-    focus
-    it "saves urls for groups that have signup forms but no saved urls" do
-      needing_backfill = -> do
-        Group.all
-          .select{ |g| g.signup_forms.first.present? && g.signup_url.nil? }
-          .count
-      end
-
-      needing_backfill.call.must_equal 1
-      Migration.backfill_signup_urls
-      needing_backfill.call.must_equal 0
-    end
-  end
 end


### PR DESCRIPTION
this resolves #521
___________________________

# Notes

* add optional phone number field to signup form
* require all other fields

PLEASE NOTE: I saw and ignored many things we could improve in the signup form (for example adding password field, logging user in after signup, etc...) because they are part of a bigger UX overhaul discussed in #573 and have (i think) been explicitly descoped from the "must have for soft launch" bucket of work

# Screenshots

Revised fields (w/ required labels):

![signup-revised-fields](https://user-images.githubusercontent.com/6032844/38396315-40e1c914-3905-11e8-9cd1-08a504cd26a2.png)

Submitting without filling in required fields:

![signup-revised-fileds-failed-submit](https://user-images.githubusercontent.com/6032844/38396330-56a5a234-3905-11e8-9cee-0b6e0324b087.png)



