### PR TITLE
resolve "disable fb events permissions"

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -251,11 +251,14 @@ Devise.setup do |config|
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
 
 
-  config.omniauth :facebook, ENV['FACEBOOK_APP_ID'], ENV['FACEBOOK_APP_SECRET'],
-                  scope: 'user_events,rsvp_event,email'
   config.omniauth :twitter, ENV['TWITTER_APP_ID'], ENV['TWITTER_APP_SECRET']
   config.omniauth :google_oauth2, ENV['GOOGLE_APP_ID'], ENV['GOOGLE_APP_SECRET']
-
+  # TODO: (aguestuser|05 Apr 2018)
+  # reenable user_events, rspv_events scopes after login review
+  config.omniauth :facebook,
+                  ENV['FACEBOOK_APP_ID'],
+                  ENV['FACEBOOK_APP_SECRET'],
+                  scope: 'email'
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
this resolves #598 

# Notes

* disable the FB OAuth events scope since it requires a review process we have not completed (and is also broken)
* as a result, prevent users from seeing scary warning when they login w/ FB

# Screenshots

before disabling (scary!):

![fb-oauth-dialogue-scary](https://user-images.githubusercontent.com/6032844/38396983-20fa1350-3909-11e8-9a04-6af0bd7bb9d3.png)

after disabling (not scary!)

![fb-oauth-dialogue-not-scary](https://user-images.githubusercontent.com/6032844/38396990-2a979554-3909-11e8-8473-39cd3b5a1fa2.png)
