### PR TITLE
resolve "link to subgroup creation form in dashboard resources"

### DIFF
--- a/app/models/concerns/url_helpers.rb
+++ b/app/models/concerns/url_helpers.rb
@@ -1,0 +1,3 @@
+module UrlHelpers
+  UrlHelpers = Rails.application.routes.url_helpers
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,6 +1,7 @@
 class Group < ApplicationRecord
   include ArelHelpers::ArelTable
   include Networkable
+  include UrlHelpers
   #has_paper_trail
   acts_as_taggable
 
@@ -184,14 +185,18 @@ class Group < ApplicationRecord
     "#{slugified_group_name}#{email_base}"
   end
 
+  # PREDICATES
+  def has_signup_form?
+    !signup_forms.empty?
+  end
+
   # ACCESSORS
   def signup_url
     has_signup_form? &&
-      Rails.application.routes.url_helpers.
-        new_group_signup_form_signup_url(self, signup_forms.first)
+      UrlHelpers.new_group_signup_form_signup_url(self, signup_forms.first)
   end
 
-  def has_signup_form?
-    !signup_forms.empty?
+  def new_subgroup_url
+    UrlHelpers.new_group_subgroup_url(self)
   end
 end

--- a/app/representers/json_api/group_representer.rb
+++ b/app/representers/json_api/group_representer.rb
@@ -11,6 +11,7 @@ class JsonApi::GroupRepresenter < Roar::Decorator
     property :browser_url
     property :featured_image_url
     property :signup_url
+    property :new_subgroup_url
 
     property :creator, extend: JsonApi::PeopleRepresenter, class: Person
   end

--- a/client/app/bundles/Events/components/GroupResources.jsx
+++ b/client/app/bundles/Events/components/GroupResources.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const GroupResources = ({resources}) => (
   <div>
-    <h4>Resources:</h4>
+    <h4>Resources</h4>
     {
       EmptyListOf(resources) ||
       <ul>

--- a/client/app/bundles/Events/containers/Dashboard.jsx
+++ b/client/app/bundles/Events/containers/Dashboard.jsx
@@ -56,7 +56,9 @@ class Dashboard extends Component {
         <hr/>
         <GroupResources {...{
           resources: [{
-            description: 'Signup Page', link: attributes['signup-url']
+            description: 'Recruit new members', link: attributes['signup-url'],
+          },{
+            description: 'Recruit new subgroups', link: attributes['new-subgroup-url'],
           }]
         }}/>
         <hr/>

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -223,12 +223,20 @@ class GroupTest < ActiveSupport::TestCase
   end
 
   describe "accessors" do
-      it "returns the group's signup page url" do
+    it "returns the group's signup page url" do
       groups(:fantastic_four)
         .signup_url
         .must_equal 'http://localhost:3000' +
                     '/groups/1036040811' +
                     '/signup_forms/350404309/signups/new'
+    end
+
+    it "returns the group's subgroup creation url" do
+      groups(:fantastic_four)
+        .new_subgroup_url
+        .must_equal 'http://localhost:3000' +
+                    '/groups/1036040811' +
+                    '/subgroups/new'
     end
   end
 


### PR DESCRIPTION
resolves #599 

_____________________________________

# Notes

* include a link to new subgroup form in resources list (since we're always trying to remember that, organizers likely will too!)
* reword resources listings to "recruit new _____" (member or subgroup)
* add `UrlHelpers` concern (to type less when using url helpers in model code)

# Screenshot

![new-subgroup-link-in-resource-list](https://user-images.githubusercontent.com/6032844/38397784-9df17ed0-390d-11e8-870a-5e0668021903.png)
