### PR TITLE
resolve "add/edit member in a 'modal'"

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -257,3 +257,29 @@ input:checked + .slider:before {
         margin: 0;
     }
 }
+
+.modal-background {
+    background-color: lightgray;
+    padding-left: 4rem;
+    padding-right: 4rem;
+}
+
+.modal-header {
+    @extend .modal-background;
+}
+
+.modal-container {
+    @extend .modal-background;
+    margin-top: -.5rem;
+    padding-bottom: 4rem;
+}
+
+.modal-actions {
+    display: flex;
+    flex-direction: row;
+    padding-bottom: 1rem;
+    justify-content: flex-start;
+    .btn {
+        margin: 0 .5rem 0 .5rem;
+    }
+}

--- a/app/views/layouts/_modal_header.html.erb
+++ b/app/views/layouts/_modal_header.html.erb
@@ -1,0 +1,8 @@
+<div class="container-html modal-header">
+  <div class='page-header'>
+    <div class="row container">
+      <div class="col-10">
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -1,3 +1,5 @@
+<% # locals: cancel_url %>
+
 <%= form_for @member, as: :person, class: 'form-inline', url: url  do |f| %>
   <%= render partial: "error_alert" %>
   <div class="field form-group mt-5">
@@ -18,7 +20,7 @@
     <%= f.text_field :gender_identity, class: 'form-control col-5' %>
   </div>
   <div class="field form-group">
-    <%= f.label :party_identification, class: 'col-2 col-form-label float-left' %>
+    <%= f.label 'party', class: 'col-2 col-form-label float-left' %>
     <%= f.text_field :party_identification, class: 'form-control col-5' %>
   </div>
   <div class="field form-group">
@@ -51,7 +53,8 @@
         </div>
       </div>
   </section>
-  <div class="actions">
+  <div class="actions modal-actions">
     <%= f.submit "Submit", class: "btn btn-primary" %>
+    <%= link_to "Cancel", cancel_path,  class: "btn btn-danger" %>
   </div>
 <% end %>

--- a/app/views/members/edit.html.erb
+++ b/app/views/members/edit.html.erb
@@ -1,15 +1,13 @@
-<%= render 'groups/navigation' %>
-<div class = "container-html">
+<%= render 'layouts/modal_header' %>
+<div class = "container-html modal-container">
   <div class="card">
     <div class="card-block">
-      <h3>Editing Person</h3>
+      <h3>Editing Member</h3>
       <div>
-        <%= render 'form', member: @member, url: group_member_path(@group) %>
+        <%= render 'form', person: @person,
+                           url: group_member_path(@group),
+                           cancel_path: group_member_path(@group, @member) %>
       </div>
     </div>
   </div>
 </div>
-
-
-
-

--- a/app/views/members/new.html.erb
+++ b/app/views/members/new.html.erb
@@ -1,10 +1,12 @@
-<%= render 'groups/navigation' %>
-<div class = "container-html">
+<%= render 'layouts/modal_header' %>
+<div class="container-html modal-container">
   <div class="card">
     <div class="card-block">
       <h3>Add Member</h3>
       <div>
-        <%= render 'form', person: @person, url: group_members_path(@group, @member) %>
+        <%= render 'form', person: @person,
+                           url: group_members_path(@group, @member),
+                           cancel_path: group_members_path(@group) %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
resolves #593 
_____________________________

# Notes

* instead of fixing tab mess, hide it!
* whenever we add or edit a member, hide all the chorme
* provide a "cancel" button to take user back to either members list (if adding) or member profile (if editing)
* bonus: reword test on edit member page that used to say "Edit Person"

# Screenshots

new member page:

![new-member-modal](https://user-images.githubusercontent.com/6032844/38398866-b5e1563a-3914-11e8-8b68-60bacc1724ba.png)

edit member page:

![edit-member-modal](https://user-images.githubusercontent.com/6032844/38398870-bcb9e0d0-3914-11e8-93dc-89e81abe6b2d.png)
