### PR TITLE
resolve "revise fields in add/edit member form"

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,6 +18,7 @@
 
 @import "./signup_form.scss";
 @import "./create_group_form.scss";
+@import "./member_form.scss";
 
 $red: #d9534f;
 $green: #5cb85c;
@@ -255,31 +256,5 @@ input:checked + .slider:before {
     margin: 2rem 0 2rem 0;
     p {
         margin: 0;
-    }
-}
-
-.modal-background {
-    background-color: lightgray;
-    padding-left: 4rem;
-    padding-right: 4rem;
-}
-
-.modal-header {
-    @extend .modal-background;
-}
-
-.modal-container {
-    @extend .modal-background;
-    margin-top: -.5rem;
-    padding-bottom: 4rem;
-}
-
-.modal-actions {
-    display: flex;
-    flex-direction: row;
-    padding-bottom: 1rem;
-    justify-content: flex-start;
-    .btn {
-        margin: 0 .5rem 0 .5rem;
     }
 }

--- a/app/assets/stylesheets/member_form.scss
+++ b/app/assets/stylesheets/member_form.scss
@@ -1,0 +1,61 @@
+
+
+.modal-background {
+    background-color: lightgray;
+    padding-left: 4rem;
+    padding-right: 4rem;
+}
+
+.modal-header {
+    @extend .modal-background;
+}
+
+.modal-container {
+    @extend .modal-background;
+    margin-top: -.5rem;
+    padding-bottom: 4rem;
+    h3 {
+        text-align: center;
+    }
+    .card {
+        width: 66%!important;
+        margin-left: auto;
+        margin-right: auto;
+        margin-bottom: 50%;
+    }
+    .multi-value-fields{
+        display: flex;
+        flex-direction: row;
+        align-content: flex-start;
+        align-items: center;
+        .btn {
+            margin-left: .5rem;
+        }
+        input {
+            padding-left: .1rem;
+        }
+    }
+    input.wide{
+        @extend .col-12;
+        padding-left: .1rem;
+    }
+    input.thin {
+        @extend .col-8;
+        @extend .mr-4;
+    }
+}
+
+.modal-actions {
+    display: flex;
+    flex-direction: row;
+    padding-bottom: 1rem;
+    justify-content: center;
+    .btn {
+        margin: 0 .5rem 0 .5rem;
+    }
+}
+
+.add-contact-field {
+    margin-top: 0;
+}
+

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -116,7 +116,8 @@ class MembersController < ApplicationController
           custom_fields: {},
           memberships_attributes: [:id, :role],
           phone_numbers_attributes: [:id, :number, :primary, :_destroy],
-          email_addresses_attributes: [:id, :address, :primary, :_destroy]
+          email_addresses_attributes: [:id, :address, :primary, :_destroy],
+          personal_addresses_attributes: [:id, :postal_code]
       )
   end
 

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -42,8 +42,9 @@ class MembersController < ApplicationController
   # GET /groups/:id/members/new
   def new
     @member = @group.members.new
+    @member.personal_addresses.build(primary: true)
     @member.email_addresses.build(primary: true)
-    @member.phone_numbers.build(primary: true)
+    @member.phone_numbers.build
     authorize! :manage, @group
   end
 
@@ -117,7 +118,7 @@ class MembersController < ApplicationController
           memberships_attributes: [:id, :role],
           phone_numbers_attributes: [:id, :number, :primary, :_destroy],
           email_addresses_attributes: [:id, :address, :primary, :_destroy],
-          personal_addresses_attributes: [:id, :postal_code]
+          personal_addresses_attributes: [:id, :primary, :postal_code]
       )
   end
 

--- a/app/models/signup_form.rb
+++ b/app/models/signup_form.rb
@@ -29,7 +29,7 @@ class SignupForm < CustomForm
         name: "#{group.name}_default_signup_form",
         title: "#{group.name}",
         description: group.description || "<div></div>",
-        call_to_action: "get involved"
+        call_to_action: "join our group"
       ),
       person_input_group: PersonInputGroup.new(
         inputs: %w[given_name family_name],

--- a/app/services/migration.rb
+++ b/app/services/migration.rb
@@ -61,6 +61,7 @@ class Migration
         sf.email_input_group&.update!(required: %w[address])
         sf.address_input_group&.update!(required: %w[postal_code])
         sf.phone_input_group&.update!(inputs: %w[number], required: [])
+        sf.update!(call_to_action: 'join our group')
       end
     end
   end

--- a/app/views/members/_email_address_fields.html.erb
+++ b/app/views/members/_email_address_fields.html.erb
@@ -1,9 +1,8 @@
-<div class="nested-fields field pb-3 form-group">
-  <%= f.label :address, 'Email address', class: 'col-2 col-form-label float-left' %>
-  <%= f.text_field :address, class: 'mr-4 float-left' %>
-  <%= f.check_box :primary , class: 'js-email-primary'%>
-  <%= f.label :primary %>
-  <%= link_to_remove_association 'Remove', f, class: 'btn btn-danger btn-sm' %>
+<div class="multi-value-fields field form-group">
+  <%= f.text_field :address, class: 'thin', placeholder: 'Email*' %>
+  <div class="multi-contact-info-group">
+    <%= f.check_box :primary , class: 'js-email-primary'%>
+    <%= f.label :primary %>
+    <%= link_to_remove_association 'Remove', f, class: 'btn btn-danger btn-sm' %>
+  </div>
 </div>
-
-

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -3,45 +3,42 @@
 <%= form_for @member, as: :person, url: url  do |f| %>
   <%= render partial: "error_alert" %>
 
-  <div class="field form-group mt-3">
+  <div class="form-group mt-3">
       <%= f.text_field :given_name, placeholder: 'First Name*', required: true, class: 'wide' %>
   </div>
 
-  <div class="field form-group">
+  <div class="form-group">
     <%= f.text_field :family_name, placeholder: 'Last Name*', required: true, class: 'wide' %>
   </div>
 
-  <div class="field form-group">
-    <%= f.fields_for :personal_addresses do |address_form| %>
-      <%= address_form.text_field :postal_code, placeholder: 'Zip Code*', required: true, class: 'wide' %>
-      <%= address_form.hidden_field :primary, value: true %>
+  <div class="form-group">
+    <%= f.fields_for :personal_addresses do |ff| %>
+      <%= ff.text_field :postal_code, placeholder: 'Zip Code*', required: true, class: 'wide' %>
+      <%= ff.hidden_field :primary, value: true %>
     <% end # f.fields_for :personal_addresses %>
   </div>
 
-  <section class="pb-4">
-    <div class="js-email_addresses">
-      <%= f.fields_for :email_addresses do |email_address_form| %>
-        <%= render 'email_address_fields', f: email_address_form %>
-      <% end %>
-      <div class="links">
-        <%= link_to_add_association 'Add Email Address', f, :email_addresses, class: 'add-contact-field' %>
-      </div>
+  <div class="pb-4 js-email_addresses">
+    <%= f.fields_for :email_addresses do |email_address_form| %>
+      <%= render 'email_address_fields', f: email_address_form %>
+    <% end %>
+    <div class="links">
+      <%= link_to_add_association 'Add Email Address', f, :email_addresses, class: 'add-contact-field' %>
     </div>
-  </section>
+  </div>
 
-  <section class="pb-4">
-    <div class="js-phone_numbers">
-        <%= f.fields_for :phone_numbers do |phone_number_form| %>
-          <%= render 'phone_number_fields', f: phone_number_form %>
-        <% end %>
-        <div class="links">
-          <%= link_to_add_association 'Add Phone Number', f, :phone_numbers %>
-        </div>
-      </div>
-  </section>
-  
+  <div class="pb-4 js-phone_numbers">
+    <%= f.fields_for :phone_numbers, @member.phone_numbers.first do |phone_number_form| %>
+      <%= render 'phone_number_fields', f: phone_number_form %>
+    <% end %>
+    <div class="links">
+      <%= link_to_add_association 'Add Phone Number', f, :phone_numbers %>
+    </div>
+  </div>
+
   <div class="actions modal-actions">
     <%= f.submit "Submit", class: "btn btn-primary" %>
     <%= link_to "Cancel", cancel_path,  class: "btn btn-danger" %>
   </div>
-<% end %>
+
+<% end # form_for @member %>

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -10,10 +10,11 @@
   <div class="field form-group">
     <%= f.text_field :family_name, placeholder: 'Last Name*', required: true, class: 'wide' %>
   </div>
-  
+
   <div class="field form-group">
     <%= f.fields_for :personal_addresses do |address_form| %>
-      <%= address_form.text_field :postal_code, placeholder: 'Zipcode*', required: true, class: 'wide' %>
+      <%= address_form.text_field :postal_code, placeholder: 'Zip Code*', required: true, class: 'wide' %>
+      <%= address_form.hidden_field :primary, value: true %>
     <% end # f.fields_for :personal_addresses %>
   </div>
 

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -1,49 +1,36 @@
 <% # locals: cancel_url %>
 
-<%= form_for @member, as: :person, class: 'form-inline', url: url  do |f| %>
+<%= form_for @member, as: :person, url: url  do |f| %>
   <%= render partial: "error_alert" %>
   <div class="field form-group mt-5">
-      <%= f.label :given_name, class: 'col-2 col-form-label float-left'%>
-      <%= f.text_field :given_name, class: 'form-control col-5' %>
+      <%= f.text_field :given_name,
+          placeholder: 'First Name*',
+          required: true,
+          class: 'wide' %>
+  </div>
+  <div class="field form-group">
+    <%= f.text_field :family_name,
+        placeholder: 'Last Name*',
+        required: true,
+        class: 'wide' %>
   </div>
 
   <div class="field form-group">
-    <%= f.label :family_name, class: 'col-2 col-form-label float-left' %>
-    <%= f.text_field :family_name, class: 'form-control col-5' %>
+
   </div>
-  <div class="field form-group">
-    <%= f.label :gender, class: 'col-2 col-form-label float-left' %>
-    <%= f.select :gender, @member.gender_options, {}, class: 'form-control col-5' %>
-  </div>
-  <div class="field form-group">
-    <%= f.label :gender_identity, class: 'col-2 col-form-label float-left' %>
-    <%= f.text_field :gender_identity, class: 'form-control col-5' %>
-  </div>
-  <div class="field form-group">
-    <%= f.label 'party', class: 'col-2 col-form-label float-left' %>
-    <%= f.text_field :party_identification, class: 'form-control col-5' %>
-  </div>
-  <div class="field form-group">
-    <%= f.label :birthdate, class: 'col-2 col-form-label float-left' %>
-    <%= f.text_field :birthdate, class: 'form-control col-5' %>
-  </div>
-  <div class="field form-group">
-    <%= f.label :employer, class: 'col-2 col-form-label float-left' %>
-    <%= f.text_field :employer, class: 'form-control col-5' %>
-  </div>
+
   <section class="pb-4">
-    <h4 class="pb-2">Email Addreses</h4>
     <div class="js-email_addresses">
-        <%= f.fields_for :email_addresses do |email_address| %>
-        <%= render 'email_address_fields', f: email_address %>
-        <% end %>
-        <div class="links">
-          <%= link_to_add_association 'Add Email Address', f, :email_addresses, class: 'email-field' %>
-        </div>
+      <%= f.fields_for :email_addresses do |email_address| %>
+        <%= render 'email_address_fields', f: email_address, ff: f %>
+      <% end %>
+      <div class="links">
+        <%= link_to_add_association 'Add Email Address', f, :email_addresses, class: 'add-contact-field' %>
       </div>
+    </div>
   </section>
+
   <section class="pb-4">
-    <h4 class="pb-2">Phone Numbers</h4>
     <div class="js-phone_numbers">
         <%= f.fields_for :phone_numbers do |phone_number| %>
           <%= render 'phone_number_fields', f: phone_number %>

--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -2,27 +2,25 @@
 
 <%= form_for @member, as: :person, url: url  do |f| %>
   <%= render partial: "error_alert" %>
-  <div class="field form-group mt-5">
-      <%= f.text_field :given_name,
-          placeholder: 'First Name*',
-          required: true,
-          class: 'wide' %>
-  </div>
-  <div class="field form-group">
-    <%= f.text_field :family_name,
-        placeholder: 'Last Name*',
-        required: true,
-        class: 'wide' %>
+
+  <div class="field form-group mt-3">
+      <%= f.text_field :given_name, placeholder: 'First Name*', required: true, class: 'wide' %>
   </div>
 
   <div class="field form-group">
-
+    <%= f.text_field :family_name, placeholder: 'Last Name*', required: true, class: 'wide' %>
+  </div>
+  
+  <div class="field form-group">
+    <%= f.fields_for :personal_addresses do |address_form| %>
+      <%= address_form.text_field :postal_code, placeholder: 'Zipcode*', required: true, class: 'wide' %>
+    <% end # f.fields_for :personal_addresses %>
   </div>
 
   <section class="pb-4">
     <div class="js-email_addresses">
-      <%= f.fields_for :email_addresses do |email_address| %>
-        <%= render 'email_address_fields', f: email_address, ff: f %>
+      <%= f.fields_for :email_addresses do |email_address_form| %>
+        <%= render 'email_address_fields', f: email_address_form %>
       <% end %>
       <div class="links">
         <%= link_to_add_association 'Add Email Address', f, :email_addresses, class: 'add-contact-field' %>
@@ -32,14 +30,15 @@
 
   <section class="pb-4">
     <div class="js-phone_numbers">
-        <%= f.fields_for :phone_numbers do |phone_number| %>
-          <%= render 'phone_number_fields', f: phone_number %>
+        <%= f.fields_for :phone_numbers do |phone_number_form| %>
+          <%= render 'phone_number_fields', f: phone_number_form %>
         <% end %>
         <div class="links">
           <%= link_to_add_association 'Add Phone Number', f, :phone_numbers %>
         </div>
       </div>
   </section>
+  
   <div class="actions modal-actions">
     <%= f.submit "Submit", class: "btn btn-primary" %>
     <%= link_to "Cancel", cancel_path,  class: "btn btn-danger" %>

--- a/app/views/members/_phone_number_fields.html.erb
+++ b/app/views/members/_phone_number_fields.html.erb
@@ -1,8 +1,8 @@
-<div class="nested-fields field pb-3 field form-group">
-  <%= f.label :number, 'phone number', class: 'col-2 col-form-label float-left' %>
-  <%= f.text_field :number, class: 'mr-4 float-left phone-input' %>
-  <%= f.check_box :primary, class: 'js-phone-primary' %>
-  <%= f.label :primary %>
-  <%= link_to_remove_association "Remove", f, class: 'btn btn-danger btn-sm' %>
+<div class="multi-value-fields field form-group">
+  <%= f.text_field :number, class: 'thin', placeholder: 'Phone' %>
+  <div class="multi-contact-info-group">
+    <%= f.check_box :primary, class: 'js-phone-primary' %>
+    <%= f.label :primary %>
+    <%= link_to_remove_association "Remove", f, class: 'btn btn-danger btn-sm' %>
+  </div>
 </div>
-

--- a/app/views/members/edit.html.erb
+++ b/app/views/members/edit.html.erb
@@ -2,7 +2,7 @@
 <div class = "container-html modal-container">
   <div class="card">
     <div class="card-block">
-      <h3>Editing Member</h3>
+      <h3>Edit Member</h3>
       <div>
         <%= render 'form', person: @person,
                            url: group_member_path(@group),

--- a/app/views/subgroups/new.html.erb
+++ b/app/views/subgroups/new.html.erb
@@ -83,8 +83,8 @@
 
                 <!-- zip -->
                 <div class="field">
-                  <%= member_form.fields_for :personal_addresses_attributes, address do |email_form| %>
-                    <%= email_form.text_field :postal_code, placeholder: 'Zipcode (personal)' %>
+                  <%= member_form.fields_for :personal_addresses_attributes, address do |address_form| %>
+                    <%= address_form.text_field :postal_code, placeholder: 'Zipcode (personal)' %>
                   <% end #member_form.fields_for :email_address %>
                 </div>
               <% end %>

--- a/test/feature/add_edit_member_test.rb
+++ b/test/feature/add_edit_member_test.rb
@@ -1,0 +1,73 @@
+require_relative "../test_helper"
+
+class AddEditMember < FeatureTest
+  let(:group){ groups(:fantastic_four) }
+  let(:organizer){ people(:human_torch) }
+  let(:person_count){ Person.count }
+  let(:add_member_attrs) do
+    {
+
+    }
+  end
+  let(:edit_member_attrs) do
+    {
+      'First Name*' =>  'funny',
+      'Last Name*'  =>  'cat',
+      'Email*'      =>  'funn@cat.com',
+      'Zip Code*'   =>  '99999',
+      'Phone'       =>  '999-999-9999',
+    }
+  end
+
+  describe "adding a member" do
+    before do
+      person_count
+      login_as organizer
+      visit "/groups/#{group.id}/members/new"
+      fill_out_form('First Name*' =>  'serious',
+                    'Last Name*'  =>  'person',
+                    'Email*'      =>  'serious@person.com',
+                    'Zip Code*'   =>  '11111',
+                    'Phone'       =>  '111-111-1111')
+      click_button 'Submit'
+    end
+
+    it "creates a new person" do
+      Person.count.must_equal(person_count + 1)
+    end
+
+    it "makes person member of group" do
+      group.members.last.must_equal Person.last
+    end
+
+    it "saves form entries" do
+      p = Person.last
+      p.given_name.must_equal 'serious'
+      p.family_name.must_equal 'person'
+      p.primary_email_address.must_equal 'serious@person.com'
+      p.primary_personal_address.postal_code.must_equal '11111'
+      p.primary_phone_number.must_equal '111-111-1111'
+    end
+
+    describe "editing member" do
+      before do
+        visit "/groups/#{group.id}/members/#{Person.last.id}/edit"
+        fill_out_form('First Name*' =>  'funny',
+                      'Last Name*'  =>  'cat',
+                      'Email*'      =>  'funny@cat.com',
+                      'Zip Code*'   =>  '22222',
+                      'Phone'       =>  '222-222-2222')
+        click_button 'Submit'
+      end
+
+      it "saves form entries" do
+        p = Person.last
+        p.given_name.must_equal 'funny'
+        p.family_name.must_equal 'cat'
+        p.primary_personal_address.postal_code.must_equal '22222'
+        p.primary_email_address.must_equal 'funny@cat.com'
+        p.primary_phone_number.must_equal '222-222-2222'
+      end
+    end
+  end
+end

--- a/test/feature/add_edit_member_test.rb
+++ b/test/feature/add_edit_member_test.rb
@@ -4,25 +4,11 @@ class AddEditMember < FeatureTest
   let(:group){ groups(:fantastic_four) }
   let(:organizer){ people(:human_torch) }
   let(:person_count){ Person.count }
-  let(:add_member_attrs) do
-    {
-
-    }
-  end
-  let(:edit_member_attrs) do
-    {
-      'First Name*' =>  'funny',
-      'Last Name*'  =>  'cat',
-      'Email*'      =>  'funn@cat.com',
-      'Zip Code*'   =>  '99999',
-      'Phone'       =>  '999-999-9999',
-    }
-  end
 
   describe "adding a member" do
     before do
-      person_count
       login_as organizer
+      person_count
       visit "/groups/#{group.id}/members/new"
       fill_out_form('First Name*' =>  'serious',
                     'Last Name*'  =>  'person',
@@ -47,6 +33,29 @@ class AddEditMember < FeatureTest
       p.primary_email_address.must_equal 'serious@person.com'
       p.primary_personal_address.postal_code.must_equal '11111'
       p.primary_phone_number.must_equal '111-111-1111'
+    end
+
+    describe "without providing required fields" do
+      it "does not save form entries" do
+        assert_difference ->{Person.count}, 0 do
+          visit "/groups/#{group.id}/members/new"
+          click_button 'Submit'
+        end
+      end
+    end
+
+    describe "without providing optional fields" do
+      it "saves form entries" do
+        assert_difference ->{Person.count}, 1 do
+          visit "/groups/#{group.id}/members/new"
+          fill_out_form('First Name*' =>  'optional',
+                        'Last Name*'  =>  'person',
+                        'Email*'      =>  'optional@person.com',
+                        'Zip Code*'   =>  '11111',
+                        'Phone'       =>  '')
+          click_button 'Submit'
+        end
+      end
     end
 
     describe "editing member" do

--- a/test/models/signup_form_test.rb
+++ b/test/models/signup_form_test.rb
@@ -38,7 +38,7 @@ class SignupFormTest < ActiveSupport::TestCase
       specify { f.name.must_equal "#{group.name}_default_signup_form" }
       specify { f.title.must_equal group.name }
       specify { f.description.must_equal group.description }
-      specify { f.call_to_action.must_equal "get involved" }
+      specify { f.call_to_action.must_equal "join our group" }
 
       it 'includes correct person fields' do
         f.person_input_group.inputs


### PR DESCRIPTION
resolves #607 
________________________________

# Notes
* removes gender, gender identity, party, birthday fields
* adds zipcode field (and ensures it belongs to *primary* address)
* restyles add/edit member forms to with more compact layout

# Screenshots


![add-member](https://user-images.githubusercontent.com/6032844/38536810-235cc0cc-3c59-11e8-94e5-ffbf4eeaa790.png)

![edit-member](https://user-images.githubusercontent.com/6032844/38536845-65131002-3c59-11e8-8d35-76f7a4055031.png)

