### PR TITLE
[bugfix] don't fetch google groups when group has no `group_key`

### DIFF
--- a/app/services/google_api/service.rb
+++ b/app/services/google_api/service.rb
@@ -43,7 +43,7 @@ class GoogleAPI::Service
 
   # (String) => GoogleAPI::Service
   def fetch_google_group(group_key:)
-    return self unless @directory_service
+    return self unless @directory_service && group_key
     @google_group = FetchGoogleGroup.call(
       directory_service: @directory_service,
       group_key: group_key

--- a/test/services/google_api/service_test.rb
+++ b/test/services/google_api/service_test.rb
@@ -194,6 +194,19 @@ class GoogleAPI::ServiceTest < ActiveSupport::TestCase
         expect(GoogleAPI::FetchGoogleGroup).not_to have_received(:call)
       end
     end
+
+    describe "when group_key is nil" do
+      before do
+        allow(GoogleAPI::FetchGoogleGroup).to receive(:call)
+        GoogleAPI::Service
+          .new(directory_service: directory_service_double)
+          .fetch_google_group(group_key: nil)
+      end
+
+      it "does not try to fetch google group" do
+        expect(GoogleAPI::FetchGoogleGroup).not_to have_received(:call)
+      end
+    end
   end
 
   describe "#add_member_to_google_group" do


### PR DESCRIPTION
* bug: some groups exist in networks that have gsuite support enabled, but we  did not store google group id's for them when they were created. thus, when we try to fetch their google group from the google API, we pass a nil `group_key` and we get a (maddeningly opaque!) `Bad Reqeust` error
* fix: check to see if `group_key` is nil, and don't hit the google api if it is