### PR TITLE
resolve "login user after email signup"

### DIFF
--- a/app/controllers/signups_controller.rb
+++ b/app/controllers/signups_controller.rb
@@ -15,8 +15,8 @@ class SignupsController < ApplicationController
       render :new
     else
       Signups::AfterCreate.call(member: @member, group: @group)
-      redirect_to group_member_path(@group, @member),
-                  notice: "You joined #{@group.name}"
+      flash[:notice] = "You joined #{@group.name}"
+      sign_in_and_redirect(@member)
     end
   end
 

--- a/test/feature/signup_test.rb
+++ b/test/feature/signup_test.rb
@@ -64,6 +64,12 @@ class Signup < FeatureTest
           new_member.reload.send(msg).first.primary?.must_equal true
         end
       end
+
+      it "redirects to member homepage" do
+        # TODO (aguestuser|12 Apr 2018)
+        # change this to "/home" when playing #571
+        current_path.must_equal "/profile"
+      end
     end
 
     describe "with errors" do


### PR DESCRIPTION
this resolves #617 

# Notes

* title says it all: login and redirect a newly signed up member after they fill out signup form (via "email path")
* note that we do *not* require a password for this login
* yes, that's weird. we'll fix it in #613

# Screenshots

before clicking submit:

![signup-pre-click](https://user-images.githubusercontent.com/6032844/38704404-31805200-3e74-11e8-8087-6999a3bf2334.png)

after clicking submit:
![signup-post-click-0](https://user-images.githubusercontent.com/6032844/38704417-3f4ec272-3e74-11e8-853f-824477fc789a.png)


after clicking on group name (note as a member -- not an organizer -- you don't see the full page):
![signup-post-click](https://user-images.githubusercontent.com/6032844/38704424-44b37456-3e74-11e8-92e2-5da6b88adf47.png)

