### PR TITLE
[nostory|bug] cleanup fix to signup link in welcome email

### DIFF
--- a/app/mailers/organizer_mailer.rb
+++ b/app/mailers/organizer_mailer.rb
@@ -1,7 +1,7 @@
 class OrganizerMailer < ApplicationMailer
 
-  def new_subgroup_email(organizer, subgroup, form)
-    @organizer = organizer; @subgroup = subgroup; @form = form
+  def new_subgroup_email(organizer, subgroup)
+    @organizer = organizer; @subgroup = subgroup;
     mail(to: @organizer.primary_email_address,
          subject: "Welcome to #{@subgroup.name}")
 

--- a/test/feature/subgroup_creation_test.rb
+++ b/test/feature/subgroup_creation_test.rb
@@ -4,7 +4,7 @@ require 'minitest/mock'
 class SubgroupCreation < FeatureTest
 
   let(:group){ groups(:one) }
-  RESOURCES = %w[group address person membership phone_number email_address signup_form].freeze
+  RESOURCES = %w[group address person membership phone_number email_address].freeze
 
   before { visit "/groups/#{group.id}/subgroups/new" }
 

--- a/test/mailers/organizer_mailer_test.rb
+++ b/test/mailers/organizer_mailer_test.rb
@@ -5,8 +5,7 @@ class OrganizerMailerTest < ActionMailer::TestCase
   describe "new_subgroup_email" do
     let(:organizer){ people(:organizer) }
     let(:subgroup){ groups(:subgroup) }
-    let(:signup_form){ forms(:group_signup) }
-    let(:mail){ OrganizerMailer.new_subgroup_email(organizer, subgroup, signup_form) }
+    let(:mail){ OrganizerMailer.new_subgroup_email(organizer, subgroup) }
     let(:body){ mail.body.raw_source }
 
     it "mentions subgroup in subject" do

--- a/test/services/subgroups/after_create_test.rb
+++ b/test/services/subgroups/after_create_test.rb
@@ -17,7 +17,6 @@ class Subgroups::AferCreateTest < ActiveSupport::TestCase
 
     it "calls OrganizerMailer" do
       expect(OrganizerMailer).to receive_message_chain(:new_subgroup_email, :deliver_later)
-      expect(SignupForm).to receive(:for)
 
       Subgroups::AfterCreate.call(organizer: Person.new, subgroup: Group.new)
     end


### PR DESCRIPTION
fixes new bug introduced by #635 

* remove signup form argument (so mailer won't fail)
* fix broken tests that still provide that argument