### PR TITLE
resolves "#653 join group as logged in user"

### DIFF
--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -124,3 +124,9 @@ $primaryblue: rgba(2, 117, 216, 1);
     @extend .btn-join;
     @extend .btn-email;
 }
+
+.btn-primary-join {
+    @extend .btn-join;
+    @extend .button;
+    @extend .btn-primary;
+}

--- a/app/assets/stylesheets/join_group_page.scss
+++ b/app/assets/stylesheets/join_group_page.scss
@@ -28,13 +28,22 @@ $primaryblue: rgba(2, 117, 216, 1);
             font-size: 1.5em;
             margin-top: .5em;
             font-weight: bold;
-            color: $blue;
+            color: $primaryblue;
         }
-        .join-button-group{
-            display: flex;
-            flex-direction: column;
+        .aside-contents {
             width: 85%;
             margin: 1rem 0;
+            text-align: center;
+        }
+        .join-button-group {
+            @extend .aside-contents;
+            display: flex;
+            flex-direction: column;
+        }
+        .already-joined-notice {
+            @extend .aside-contents;
+            padding: 0;
+            font-style: italic;
         }
     }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,15 +42,11 @@ class ApplicationController < ActionController::Base
   def authorize_group_access
     return unless current_group
     return if is_signup_form?
+    return if is_join_request?
     return if has_group_read_access?
     authorize! :manage, current_group
   end
 
-  def is_signup_form?
-    controller_name == 'members' &&
-      (action_name == 'new' || action_name == 'create') &&
-      params[:signup_mode]
-  end
 
   def has_group_read_access?
     if authorize! :read, current_group
@@ -72,17 +68,31 @@ class ApplicationController < ActionController::Base
   def authorized_controllers_and_actions?
     return true if is_public_list?
     return true if is_signup_form?
+    return true if is_join_request?
     false
-  end
-
-  def is_dashboard?
-    controller_name == 'dashboard'
   end
 
   def is_public_list?
     %w(members memberships events).include?(controller_name) &&
       action_name == 'index'
   end
+
+  def is_signup_form?
+    controller_name == 'members' &&
+      (action_name == 'new' || action_name == 'create') &&
+      params[:signup_mode]
+  end
+
+  def is_join_request?
+    current_person &&
+      controller_name == 'memberships' &&
+      action_name == 'create'
+  end
+
+  def is_dashboard?
+    controller_name == 'dashboard'
+  end
+
 
 
   rescue_from CanCan::AccessDenied do |_exception|

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -96,6 +96,7 @@ class GroupsController < ApplicationController
 
   # GET /groups/1/join
   def join
+    @membership = Membership.new
   end
 
   private

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,6 +1,7 @@
 class GroupsController < ApplicationController
   before_action :authorize_group_access, except: [:new, :join]
   before_action :set_group, only: [:show, :edit, :update, :destroy, :join]
+  before_action :set_membership, only: :join
   before_action :authenticate_person!, except: [:join]
 
   protect_from_forgery except: [:update] #TODO: Add the csrf token in react.
@@ -96,13 +97,20 @@ class GroupsController < ApplicationController
 
   # GET /groups/1/join
   def join
-    @membership = Membership.new
   end
 
   private
   # Use callbacks to share common setup or constraints between actions.
   def set_group
     @group = Group.find(params[:id] || params[:group_id])
+  end
+
+  def set_membership
+    if @group.members.include? current_person
+      @membership = Membership.find_by(group_id: @group.id, person_id: current_person.id)
+    else
+      @membership = Membership.new
+    end
   end
 
   def authorized_controllers_and_actions?

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -33,22 +33,39 @@ class MembershipsController < ApplicationController
     end
   end
 
+  # POST /memberships
+  # POST /groups/:group_id/memberships
+
+  def create
+    if @membership = Membership.create(membership_params)
+      redirect_to group_dashboard_path(@membership.group),
+                  notice: "You are now a member of #{@membership.group.name}"
+    else
+      redirect_to profile_home_path,
+                  error: "Failed to create new membership"
+    end
+  end
+
   def update
     @membership = Membership.find(:id).role
     respond_to do |format|
-    if @membership.role == "member"
-      @membership.update(role: 'organizer')
-      format.html { redirect_to group_dashboard_path, notice: 'Member is now an Organizer.' }
-      format.json { render :show, status: :created, location: @membership }
-    else
-      @membership.update(role: 'member')
-      format.html { redirect_back(fallback_location: root_path) }
-      format.json { render json: @membership.errors, status: :unprocessable_entity }
+      if @membership.role == "member"
+        @membership.update(role: 'organizer')
+        format.html { redirect_to group_dashboard_path, notice: 'Member is now an Organizer.' }
+        format.json { render :show, status: :created, location: @membership }
+      else
+        @membership.update(role: 'member')
+        format.html { redirect_back(fallback_location: root_path) }
+        format.json { render json: @membership.errors, status: :unprocessable_entity }
       end
     end
   end
 
   private
+
+  def membership_params
+    params.require(:membership).permit(:group_id, :person_id, :role)
+  end
 
   def find_memberships
 

--- a/app/views/groups/_already_joined_notice.html.erb
+++ b/app/views/groups/_already_joined_notice.html.erb
@@ -1,0 +1,4 @@
+<div class="already-joined-notice">
+  Oops! You already joined <%= link_to @group.name, group_dashboard_path(@group) %>
+  on <%= @membership.created_at.strftime('%B %d, %Y') %>.
+</div>

--- a/app/views/groups/_join_buttons_logged_in.html.erb
+++ b/app/views/groups/_join_buttons_logged_in.html.erb
@@ -1,0 +1,8 @@
+<div class="join-button-group">
+  <%=form_for @membership, url: group_memberships_path(@group) do |f| %>
+    <%= f.hidden_field :group_id, value: @group.id %>
+    <%= f.hidden_field :person_id, value: current_person.id %>
+    <%= f.hidden_field :role, value: 'member' %>
+    <%=f.submit "Join", class: "btn-primary-join" %>
+  <% end %>
+</div>

--- a/app/views/groups/_join_buttons_logged_out.html.erb
+++ b/app/views/groups/_join_buttons_logged_out.html.erb
@@ -1,0 +1,28 @@
+<div class="join-button-group">
+  <!-- join with facebook -->
+  <%= link_to omniauth_authorize_path(:person,
+                                      :facebook,
+                                      auth_mode: 'signup',
+                                      group_id: @group.id),
+              class: 'btn-facebook-join' do %>
+  <%= image_tag 'facebook-logo.svg' %>
+  <span>Join with Facebook</span>
+  <% end %>
+
+  <!-- join with google -->
+  <%= link_to omniauth_authorize_path(:person,
+                                      :google_oauth2,
+                                      auth_mode: 'signup',
+                                      group_id: @group.id),
+              class: 'btn-google-join' do %>
+  <%= image_tag 'google-logo.svg' %>
+  <span>Join with Google</span>
+  <% end %>
+
+  <!-- join with email -->
+  <%= link_to new_group_member_path(@group, signup_mode: 'email'),
+              class: 'btn-join btn-email' do %>
+  <%= image_tag 'email-icon.svg' %>
+  <span>Join with email</span>
+  <% end %>
+</div>

--- a/app/views/groups/join.html.erb
+++ b/app/views/groups/join.html.erb
@@ -15,34 +15,11 @@
         <div class="call-to-action">
           Join our group
         </div>
-        <div class="join-button-group">
-          <!-- join with facebook -->
-          <%= link_to omniauth_authorize_path(:person,
-                                              :facebook,
-                                              auth_mode: 'signup',
-                                              group_id: @group.id),
-                      class: 'btn-facebook-join' do %>
-            <%= image_tag 'facebook-logo.svg' %>
-            <span>Join with Facebook</span>
-          <% end %>
-
-          <!-- join with google -->
-          <%= link_to omniauth_authorize_path(:person,
-                                              :google_oauth2,
-                                              auth_mode: 'signup',
-                                              group_id: @group.id),
-                      class: 'btn-google-join' do %>
-            <%= image_tag 'google-logo.svg' %>
-            <span>Join with Google</span>
-          <% end %>
-
-          <!-- join with email -->
-          <%= link_to new_group_member_path(@group, signup_mode: 'email'),
-                      class: 'btn-join btn-email' do %>
-            <%= image_tag 'email-icon.svg' %>
-            <span>Join with email</span>
-          <% end %>
-        </div>
+        <% if current_person %>
+          <%= render 'join_buttons_logged_in' %>
+        <% else %>
+          <%= render 'join_buttons_logged_out' %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/groups/join.html.erb
+++ b/app/views/groups/join.html.erb
@@ -16,7 +16,11 @@
           Join our group
         </div>
         <% if current_person %>
-          <%= render 'join_buttons_logged_in' %>
+          <% if @group.members.include? current_person %>
+            <%= render 'already_joined_notice' %>
+          <% else %>
+            <%= render 'join_buttons_logged_in' %>
+          <% end %>
         <% else %>
           <%= render 'join_buttons_logged_out' %>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,7 +77,7 @@ Rails.application.routes.draw do
       resources :events
     end
 
-    resources :memberships, only: [:index, :show]
+    resources :memberships, only: [:index, :show, :create]
 
     resources :affiliates
 

--- a/test/feature/join_group_test.rb
+++ b/test/feature/join_group_test.rb
@@ -77,540 +77,684 @@ class JoinGroupTest < FeatureTest
     )
   end
 
-  describe "as a first time user" do
+  describe "as a logged-in user" do
+    let(:organizer){ people(:human_torch) }
+    let(:fantastic_four){ groups(:fantastic_four) }
+    let(:ohio_chapter){ groups(:ohio_chapter) }
 
-    before do
-      OmniAuth.config.mock_auth[:facebook] = mock_facebook_auth
-      OmniAuth.config.mock_auth[:google_oauth2] = mock_google_auth
-    end
+    before { login_as people(:human_torch) }
 
-    describe "viewing the join page" do
-      before { visit "/groups/#{group.id}/join" }
-
-      it "has a title" do
-        page.must_have_content group.name
-      end
-
-      it "has a description" do
-        page.must_have_content group.description
-      end
-
-      it "has a call to action" do
-        page.must_have_text "Join"
-      end
-
-      it "has a button for joining with email" do
-        page.must_have_link('Join with email',
-                            href: "/groups/#{group.id}/members/new?signup_mode=email")
-      end
-
-      describe "picking email path" do
-
-        before { click_link "Join with email" }
-
-        it "navigates to the new members form" do
-          current_path.must_equal "/groups/#{group.id}/members/new"
-        end
-
-        it "it sets the signup mode to email" do
-          current_params['signup_mode'].must_equal 'email'
-        end
-
-        describe "viewing email signup form" do
-          let(:submissions_by_input_label) do
-            {'Email*'      => 'serious@person.com',
-             'Password*'   => 'password',
-             'First Name*' => 'Serious',
-             'Last Name*'  => 'Person',
-             'Zip Code*'   => '11111',
-             'Phone'       => '111-111-1111',}
-          end
-          let(:labels){ submissions_by_input_label.keys }
-          let(:required_labels){ labels.select{ |l| l.include?("*") } }
-
-          it "has fields for missing contact info" do
-            labels.each do |label|
-              page.find("input[placeholder='#{label}']").wont_be_nil
-            end
-          end
-
-          it "has correct required organizer fields" do
-            required_labels.each do |label|
-              "input[placeholder='#{label}'][required='required']"
-            end
-          end
-
-          describe "going back" do
-            before { click_link 'Cancel'}
-
-            it "returns to join page when i click 'cancel'" do
-              current_path.must_equal "/groups/#{group.id}/join"
-            end
-          end # going back
-
-          describe "submitting email signup form" do
-            let(:person_count){ Person.count }
-            let(:membership_count){ Membership.count }
-
-            describe "with no errors" do
-              before do
-                person_count; membership_count
-                fill_out_form submissions_by_input_label
-                click_button 'Submit'
-              end
-
-              it "creates a new person" do
-                Person.count.must_equal person_count + 1
-              end
-
-              it "creates a new membership" do
-                Membership.count.must_equal membership_count + 1
-              end
-
-              it "stores persons's contact info" do
-                [:email_addresses, :phone_numbers, :personal_addresses].each do |msg|
-                  Person.last.send(msg).first.primary?.must_equal true
-                end
-              end
-
-              it "redirects to member homepage" do
-                current_path.must_equal "/home"
-              end
-            end # with no errors
-
-            describe "with invalid inputs" do
-              before do
-                fill_out_form(
-                  submissions_by_input_label.merge(
-                    'Email*'    => 'invalid',
-                    'Phone'     => 'invalid',
-                    'Zip Code*' => 'invalid'
-                  )
-                )
-                click_button "Submit"
-              end
-
-              it "shows an error for invalid email address" do
-                page.must_have_content(
-                  "Email address 'invalid' is not a valid email address"
-                )
-              end
-
-              it "shows an error for invalid phone number" do
-                page.must_have_content(
-                  "Phone number 'invalid' is not a valid phone number"
-                )
-              end
-
-              it "shows an error for invalid postal code" do
-                page.must_have_content(
-                  "Zip code 'invalid' is not a valid zip code"
-                )
-              end
-            end # with invalid inputs
-
-            describe "with google group integration enabled" do
-              let(:fancy_group){ groups(:ohio_chapter) }
-              let(:google_group_email){ 'ohio-chapter@nationalnetwork.com' }
-              let(:google_group_group_key){ "#{google_group_email}.test-google-a.com" }
-              let(:authentication_double){ double(Google::Auth::ServiceAccountCredentials) }
-              let(:directory_service_double){ double(Google::Apis::AdminDirectoryV1::DirectoryService)}
-              let(:google_group_double) do
-                double(Google::Apis::AdminDirectoryV1::Group,
-                       id: 1,
-                       email: google_group_email,
-                       non_editable_aliases: [google_group_group_key]
-                      )
-              end
-              let(:google_group_member_double){ double(Google::Apis::AdminDirectoryV1::Member)}
-
-              before do
-                # authentication
-                allow(Google::Auth::ServiceAccountCredentials)
-                  .to receive(:make_creds).and_return(authentication_double)
-                allow(authentication_double)
-                  .to receive(:sub=)
-                allow(Google::Auth::ServiceAccountCredentials)
-                  .to receive(:sub=)
-
-                # connecting to directory service
-                allow(Google::Apis::AdminDirectoryV1::DirectoryService)
-                  .to receive(:new).and_return(directory_service_double)
-                allow(directory_service_double)
-                  .to receive(:authorization=)
-
-                # fetching group
-                allow(directory_service_double)
-                  .to receive(:get_group).and_return(google_group_double)
-
-                # adding member
-                allow(Google::Apis::AdminDirectoryV1::Member)
-                  .to receive(:new).and_return(google_group_member_double)
-                allow(directory_service_double).to receive(:insert_member)
-
-                perform_enqueued_jobs do
-                  # fill out form!
-                  visit "/groups/#{fancy_group.id}/members/new?signup_mode=email"
-                  fill_out_form(submissions_by_input_label)
-                  click_button "Submit"
-                end
-              end
-
-              it "adds member to group's google group" do
-                expect(Google::Apis::AdminDirectoryV1::Member)
-                  .to have_received(:new).with(email: Person.last.email,
-                                               role: GoogleAPI::Roles::MEMBER)
-
-                expect(directory_service_double)
-                  .to have_received(:insert_member).with(google_group_double.id,
-                                                         google_group_member_double)
-              end
-            end # with google integrations enabled
-          end # submitting email signup form
-        end # viewing email signup form
-      end # picking email path
-
-      describe "picking facebook path" do
-        before { click_link "Join with Facebook" }
-
-        it "navigates to new members form" do
-          current_path.must_equal "/groups/#{group.id}/members/new"
-        end
-
-        it "sets the signup mode to facebook" do
-          current_params['signup_mode'].must_equal 'facebook'
-        end
-
-        it "passes non-sensitive oauth data as cleartext params" do
-          {
-            "provider" => current_params["person[oauth][provider]"],
-            "uid" => current_params["person[oauth][uid]"],
-            "credentials" => {
-              # omit token from this test
-              "expires_at" => current_params["person[oauth][credentials][expires_at]"],
-              "expires" => current_params["person[oauth][credentials][expires]"],
-            },
-            "info" => {
-              "email" => current_params["person[oauth][info][email]"],
-              "name" => current_params["person[oauth][info][name]"],
-              "image" => current_params["person[oauth][info][image]"],
-            }
-          }.must_equal(
-            mock_facebook_auth.to_hash.merge(
-              "credentials" => mock_facebook_auth
-                                 .to_hash
-                                 .fetch('credentials')
-                                 .except('token')
-            )
-          )
-        end
-
-        it "passes oauth token as encrypted param" do
-          Crypto.decrypt_with_nacl_secret(
-            current_params["person[oauth][credentials][token]"]
-          ).must_equal mock_facebook_auth.dig('credentials', 'token')
-        end
-
-        describe "viewing facebook signup form" do
-
-          let(:submissions_by_input_label) do
-            {'Zip Code*'   => '11111',
-             'Phone'       => '111-111-1111',}
-          end
-          let(:labels){ submissions_by_input_label.keys }
-          let(:required_labels){ labels.select{ |l| l.include?("*") } }
-          let(:supressed_fields) do
-            ['Email*', 'Password*', 'Fist Name*', 'Last Name*']
-          end
-
-          it "has fields for missing contact info" do
-            labels.each do |label|
-              page.find("input[placeholder='#{label}']").wont_be_nil
-            end
-          end
-
-
-          it "has correct required fields" do
-            required_labels.each do |label|
-              "input[placeholder='#{label}'][required='required']"
-            end
-          end
-
-          it "does not show suppressed fields" do
-            supressed_fields.each do |label|
-              page.all("input[placeholder='#{label}']").must_be_empty
-            end
-          end
-
-          describe "filling out facebook signup form" do
-            let(:person_count){ Person.count }
-            let(:membership_count){ Membership.count }
-            let(:identity_count){ Identity.count }
-
-            describe "with no errrors" do
-              before do
-                person_count; membership_count; identity_count
-                stub_long_lived_access_token_request.call
-                fill_out_form submissions_by_input_label
-                click_button 'Submit'
-              end
-
-              it "creates a new person" do
-                Person.count.must_equal person_count + 1
-              end
-
-              it "creates a new membership" do
-                Membership.count.must_equal membership_count + 1
-              end
-
-              it "does creates a new identity" do
-                Identity.count.must_equal identity_count + 1
-              end
-
-              it "stores persons's contact info" do
-                [:email_addresses, :phone_numbers, :personal_addresses].each do |msg|
-                  Person.last.send(msg).first.primary?.must_equal true
-                end
-              end
-
-              it "stores person's facebook identity" do
-                Identity.last.attributes.slice('uid', 'provider', 'access_token')
-                  .must_equal('uid'          => mock_facebook_auth['uid'],
-                              'provider'     => mock_facebook_auth['provider'],
-                              'access_token' => mock_facebook_auth['credentials']['token'])
-              end
-
-              it "redirects to member homepage" do
-                current_path.must_equal "/home"
-              end
-            end # with no errors
-
-            describe "with invalid inputs" do
-              before do
-                fill_out_form(
-                  submissions_by_input_label.merge(
-                    'Zip Code*' => 'invalid',
-                    'Phone'     => 'invalid',
-                  )
-                )
-                click_button "Submit"
-              end
-
-              it "shows an error for invalid phone number" do
-                page.must_have_content(
-                  "Phone number 'invalid' is not a valid phone number"
-                )
-              end
-
-              it "shows an error for invalid postal code" do
-                page.must_have_content(
-                  "Zip code 'invalid' is not a valid zip code"
-                )
-              end
-            end # with invalid inputs
-          end # filling out facebook signup form
-        end # viewing facebook signup form
-      end # picking facebook path
-
-      describe "picking google path" do
-
-        before { click_link "Join with Google" }
-
-        it "navigates to new members form" do
-          current_path.must_equal "/groups/#{group.id}/members/new"
-        end
-
-        it "sets the signup mode to google" do
-          current_params['signup_mode'].must_equal 'google'
-        end
-
-        it "passes non-sensitive oauth data as cleartext params" do
-          {
-            "provider" => current_params["person[oauth][provider]"],
-            "uid" => current_params["person[oauth][uid]"],
-            "credentials" => {
-              # omit token from this test
-              "expires_at" => current_params["person[oauth][credentials][expires_at]"],
-              "expires" => current_params["person[oauth][credentials][expires]"],
-            },
-            "info" => {
-              "email" => current_params["person[oauth][info][email]"],
-              "name" => current_params["person[oauth][info][name]"],
-              "image" => current_params["person[oauth][info][image]"],
-            }
-          }.must_equal(
-            mock_google_auth.to_hash.merge(
-              "credentials" => mock_google_auth
-                                 .to_hash
-                                 .fetch('credentials')
-                                 .except('token')
-            )
-          )
-        end
-
-        it "passes oauth token as encrypted param" do
-          Crypto.decrypt_with_nacl_secret(
-            current_params["person[oauth][credentials][token]"]
-          ).must_equal mock_google_auth.dig('credentials', 'token')
-        end
-
-        describe "viewing google signup form" do
-
-          let(:submissions_by_input_label) do
-            {'Zip Code*'   => '11111',
-             'Phone'       => '111-111-1111',}
-          end
-          let(:labels){ submissions_by_input_label.keys }
-          let(:required_labels){ labels.select{ |l| l.include?("*") } }
-          let(:supressed_fields) do
-            ['Email*', 'Password*', 'Fist Name*', 'Last Name*']
-          end
-
-          it "has fields for missing contact info" do
-            labels.each do |label|
-              page.find("input[placeholder='#{label}']").wont_be_nil
-            end
-          end
-
-          it "has correct required fields" do
-            required_labels.each do |label|
-              "input[placeholder='#{label}'][required='required']"
-            end
-          end
-
-          it "does not show suppressed fields" do
-            supressed_fields.each do |label|
-              page.all("input[placeholder='#{label}']").must_be_empty
-            end
-          end
-
-          describe "filling out google signup form" do
-            # we don't test for submission errors here: covered in email branch
-            let(:person_count){ Person.count }
-            let(:membership_count){ Membership.count }
-            let(:identity_count){ Identity.count }
-
-            describe "with no errrors" do
-              before do
-                person_count; membership_count; identity_count
-                fill_out_form submissions_by_input_label
-                click_button 'Submit'
-              end
-
-              it "creates a new person" do
-                Person.count.must_equal person_count + 1
-              end
-
-              it "creates a new membership" do
-                Membership.count.must_equal membership_count + 1
-              end
-
-              it "does creates a new identity" do
-                Identity.count.must_equal identity_count + 1
-              end
-
-              it "stores persons's contact info" do
-                [:email_addresses, :phone_numbers, :personal_addresses].each do |msg|
-                  Person.last.send(msg).first.primary?.must_equal true
-                end
-              end
-
-              it "stores person's google identity" do
-                Identity.last.attributes.slice('uid', 'provider', 'access_token')
-                  .must_equal('uid'          => mock_google_auth['uid'],
-                              'provider'     => mock_google_auth['provider'],
-                              'access_token' => mock_google_auth['credentials']['token'])
-              end
-
-              it "redirects to member homepage" do
-                current_path.must_equal "/home"
-              end
-            end # with no errors
-
-            describe "with invalid inputs" do
-              before do
-                fill_out_form(
-                  submissions_by_input_label.merge(
-                    'Zip Code*' => 'invalid',
-                    'Phone'     => 'invalid',
-                  )
-                )
-                click_button "Submit"
-              end
-
-              it "shows an error for invalid phone number" do
-                page.must_have_content(
-                  "Phone number 'invalid' is not a valid phone number"
-                )
-              end
-
-              it "shows an error for invalid postal code" do
-                page.must_have_content(
-                  "Zip code 'invalid' is not a valid zip code"
-                )
-              end
-            end # with invalid inputs
-          end # filling out google signup form
-        end # viewing google signup form
-      end # picking google path
-    end # viewing the join page
-  end # as a first time user
-
-  describe "as a user who already has an account on affinity" do
-    before do
-      OmniAuth.config.mock_auth[:facebook] = mock_facebook_auth_existing_user
-      OmniAuth.config.mock_auth[:google_oauth2] = mock_google_auth_existing_user
-      visit "/groups/#{group.id}/join"
-    end
-
-    describe "picking facebook path" do
-      let(:person_count){ Person.count }
-      let(:membership_count){ Membership.count }
-      let(:identity_count){ Identity.count }
-
+    describe "who is not a member of the group" do
       before do
-        person_count; membership_count; identity_count
-        stub_long_lived_access_token_request.call
-        click_link "Join with Facebook"
-        fill_out_form({'Zip Code*'   => '11111',
-                       'Phone'       => '111-111-1111',})
-        click_button "Submit"
+        ohio_chapter.members.wont_include organizer
+        visit "/groups/#{ohio_chapter.id}/join"
       end
 
-      it "does not create a new person" do
-        Person.count.must_equal person_count
-      end
-
-      it "creates a new membership" do
-        Membership.count.must_equal membership_count + 1
-      end
-
-      it "creates a new identity" do
-        Identity.count.must_equal identity_count + 1
-      end
-
-      it "does not change person's name" do
-        organizer.given_name.must_equal("Test")
-      end
-
-      it "stores persons's contact info" do
-        [:email_addresses, :phone_numbers, :personal_addresses].each do |msg|
-          organizer.send(msg).first.primary?.must_equal true
+      describe "viewing the join page" do
+        it "has a 'Join' button" do
+          page.must_have_button "Join"
         end
       end
 
-      it "stores person's facebook identity" do
-        Identity.last.attributes.slice('person_id', 'uid', 'provider', 'access_token')
-          .must_equal('person_id'    => organizer.id,
-                      'uid'          => mock_facebook_auth['uid'],
-                      'provider'     => mock_facebook_auth['provider'],
-                      'access_token' => mock_facebook_auth['credentials']['token'])
-      end
+      describe "clicking 'Join'" do
+        let(:person_count){ Person.count }
+        let(:membership_count){ Membership.count }
 
-      it "redirects to member homepage" do
-        current_path.must_equal "/home"
-      end
+        describe "with no errors" do
+          before do
+            person_count; membership_count
+            click_button "Join"
+          end
 
+          it "does not create a new person" do
+            Person.count.must_equal person_count
+          end
+
+          it "creates a new membership" do
+            Membership.count.must_equal membership_count + 1
+          end
+
+          it "makes user a member of the group" do
+            organizer
+              .memberships.last
+              .attributes.slice('group_id', 'role')
+              .must_equal('group_id' => ohio_chapter.id,
+                          'role' => 'member')
+          end
+
+          it "forwards user to the group's dashboard" do
+            current_path.must_equal "/groups/#{ohio_chapter.id}/dashboard"
+          end
+        end
+
+        describe "when membership could not be created" do
+          before do
+            allow(Membership).to receive(:create).and_return(nil)
+            click_button "Join"
+          end
+
+          it "redirects user to home page" do
+            current_path.must_equal "/home"
+          end
+        end
+      end
     end
   end
+
+  describe "logged out" do
+    # basic fixtures
+    let(:group){ groups(:fantastic_four) }
+    let(:organizer){ people(:organizer) }
+
+    # facebook fixtures
+    let(:fb_token) do
+      "UwlcA5KfBMIfSXx8dYmTusAs5FNmqBDQ13L6upHh84mBua5TR7sK7eGYm9FSGz6pTdfv7xzz"+
+        "iIKnPQLOEEw6icFuIFjrjSxQxHfxLpQEYWgz6zzs2U209liTg5JFRm9u7RmRzpxEaaWI9M"+
+        "9u61CAh7psEMkjqsfRBFi4hm89iJ91tACuiQGxtZhKr"
+    end
+    let(:mock_facebook_auth) do
+      OmniAuth::AuthHash.new(
+        { "provider"     => "facebook",
+          "uid"          => "100174124183958",
+          "credentials"  =>
+          { "token"        => fb_token ,
+            "expires_at"   => "1529880563",
+            "expires"      => "true" },
+          "info"         =>
+          { "email"        => "testy@affinity.works",
+            "name"         => "Testy McGee",
+            "image"        => "http://graph.facebook.com/v2.6/"+
+                              "100174124183958/picture" }
+        }
+      )
+    end
+    let(:mock_facebook_auth_existing_user) do
+      mock_facebook_auth.merge(
+        "info" => {
+          "email" => "organizer@admin.com",
+          "name"  => "DifferentlyNamed Organizer",
+          "image" => mock_facebook_auth['image']
+        }
+      )
+    end
+    let(:stub_long_lived_access_token_response) do
+      -> do
+        stub_request(
+          :get,
+          "https://graph.facebook.com/v2.9/oauth/access_token"+
+          "?client_id="+
+          "&client_secret="+
+          "&fb_exchange_token=UwlcA5KfBMIfSXx8dYmTusAs5FNmqBDQ13L6upH"+
+          "h84mBua5TR7sK7eGYm9FSGz6pTdfv7xzziIKnPQLOEEw6icFuIFjrjSxQx"+
+          "HfxLpQEYWgz6zzs2U209liTg5JFRm9u7RmRzpxEaaWI9M9u61CAh7psEMk"+
+          "jqsfRBFi4hm89iJ91tACuiQGxtZhKr&grant_type=fb_exchange_token"
+        ).to_return(:status => 200)
+      end
+    end
+
+    # google fixtures
+    let(:google_token) do
+      "ya29.GluqBT22iW1wYDxF1U295fvAkjpwtOBmp_Yym7rHmj0HIc3KcauH8f4a3Rdkc7SB"+
+        "xcU1h9lUJjeP-PgMpLhGzpoK-W43-Q53UCqMUJjxf82qJEtjm6byTgAILyWn"
+    end
+    let(:mock_google_auth) do
+      OmniAuth::AuthHash.new(
+        { "provider"     => "google",
+          "uid"          => "106985388443100843978",
+          "credentials"  =>
+          { "token"        => google_token ,
+            "expires_at"   => "1524802515",
+            "expires"      => "true" },
+          "info"         =>
+          { "email"        => "testy@affinity.works",
+            "name"         => "Testy McGee",
+            "image"        => "https://lh6.googleusercontent.com/-nw_wxuaEA_0"+
+                              "/AAAAAAAAAAI/AAAAAAAAAAc/jASoGVsZEYI/photo.jpg" },
+        }
+      )
+    end
+    let(:mock_google_auth_existing_user) do
+      mock_google_auth.merge(
+        mock_google_auth.fetch("info").merge(
+          "email" => "organizer@admin.com",
+          "name"  => "Test Organizer",
+        )
+      )
+    end
+
+    describe "as a first time user" do
+      before do
+        OmniAuth.config.mock_auth[:facebook] = mock_facebook_auth
+        OmniAuth.config.mock_auth[:google_oauth2] = mock_google_auth
+      end
+
+      describe "viewing the join page" do
+        before { visit "/groups/#{group.id}/join" }
+
+        it "has a title" do
+          page.must_have_content group.name
+        end
+
+        it "has a description" do
+          page.must_have_content group.description
+        end
+
+        it "has a call to action" do
+          page.must_have_text "Join"
+        end
+
+        it "has a button for joining with email" do
+          page.must_have_link('Join with email',
+                              href: "/groups/#{group.id}/members/new?signup_mode=email")
+        end
+
+        describe "picking email path" do
+
+          before { click_link "Join with email" }
+
+          it "navigates to the new members form" do
+            current_path.must_equal "/groups/#{group.id}/members/new"
+          end
+
+          it "it sets the signup mode to email" do
+            current_params['signup_mode'].must_equal 'email'
+          end
+
+          describe "viewing email signup form" do
+            let(:submissions_by_input_label) do
+              {'Email*'      => 'serious@person.com',
+               'Password*'   => 'password',
+               'First Name*' => 'Serious',
+               'Last Name*'  => 'Person',
+               'Zip Code*'   => '11111',
+               'Phone'       => '111-111-1111',}
+            end
+            let(:labels){ submissions_by_input_label.keys }
+            let(:required_labels){ labels.select{ |l| l.include?("*") } }
+
+            it "has fields for missing contact info" do
+              labels.each do |label|
+                page.find("input[placeholder='#{label}']").wont_be_nil
+              end
+            end
+
+            it "has correct required organizer fields" do
+              required_labels.each do |label|
+                "input[placeholder='#{label}'][required='required']"
+              end
+            end
+
+            describe "going back" do
+              before { click_link 'Cancel'}
+
+              it "returns to join page when i click 'cancel'" do
+                current_path.must_equal "/groups/#{group.id}/join"
+              end
+            end # going back
+
+            describe "submitting email signup form" do
+              let(:person_count){ Person.count }
+              let(:membership_count){ Membership.count }
+
+              describe "with no errors" do
+                before do
+                  person_count; membership_count
+                  fill_out_form submissions_by_input_label
+                  click_button 'Submit'
+                end
+
+                it "creates a new person" do
+                  Person.count.must_equal person_count + 1
+                end
+
+                it "creates a new membership" do
+                  Membership.count.must_equal membership_count + 1
+                end
+
+                it "stores persons's contact info" do
+                  [:email_addresses, :phone_numbers, :personal_addresses].each do |msg|
+                    Person.last.send(msg).first.primary?.must_equal true
+                  end
+                end
+
+                it "redirects to member homepage" do
+                  current_path.must_equal "/home"
+                end
+              end # with no errors
+
+              describe "with invalid inputs" do
+                before do
+                  fill_out_form(
+                    submissions_by_input_label.merge(
+                      'Email*'    => 'invalid',
+                      'Phone'     => 'invalid',
+                      'Zip Code*' => 'invalid'
+                    )
+                  )
+                  click_button "Submit"
+                end
+
+                it "shows an error for invalid email address" do
+                  page.must_have_content(
+                    "Email address 'invalid' is not a valid email address"
+                  )
+                end
+
+                it "shows an error for invalid phone number" do
+                  page.must_have_content(
+                    "Phone number 'invalid' is not a valid phone number"
+                  )
+                end
+
+                it "shows an error for invalid postal code" do
+                  page.must_have_content(
+                    "Zip code 'invalid' is not a valid zip code"
+                  )
+                end
+              end # with invalid inputs
+
+              describe "with google group integration enabled" do
+                let(:fancy_group){ groups(:ohio_chapter) }
+                let(:google_group_email){ 'ohio-chapter@nationalnetwork.com' }
+                let(:google_group_group_key){ "#{google_group_email}.test-google-a.com" }
+                let(:authentication_double){ double(Google::Auth::ServiceAccountCredentials) }
+                let(:directory_service_double){ double(Google::Apis::AdminDirectoryV1::DirectoryService)}
+                let(:google_group_double) do
+                  double(Google::Apis::AdminDirectoryV1::Group,
+                         id: 1,
+                         email: google_group_email,
+                         non_editable_aliases: [google_group_group_key]
+                        )
+                end
+                let(:google_group_member_double){ double(Google::Apis::AdminDirectoryV1::Member)}
+
+                before do
+                  # authentication
+                  allow(Google::Auth::ServiceAccountCredentials)
+                    .to receive(:make_creds).and_return(authentication_double)
+                  allow(authentication_double)
+                    .to receive(:sub=)
+                  allow(Google::Auth::ServiceAccountCredentials)
+                    .to receive(:sub=)
+
+                  # connecting to directory service
+                  allow(Google::Apis::AdminDirectoryV1::DirectoryService)
+                    .to receive(:new).and_return(directory_service_double)
+                  allow(directory_service_double)
+                    .to receive(:authorization=)
+
+                  # fetching group
+                  allow(directory_service_double)
+                    .to receive(:get_group).and_return(google_group_double)
+
+                  # adding member
+                  allow(Google::Apis::AdminDirectoryV1::Member)
+                    .to receive(:new).and_return(google_group_member_double)
+                  allow(directory_service_double).to receive(:insert_member)
+
+                  perform_enqueued_jobs do
+                    # fill out form!
+                    visit "/groups/#{fancy_group.id}/members/new?signup_mode=email"
+                    fill_out_form(submissions_by_input_label)
+                    click_button "Submit"
+                  end
+                end
+
+                it "adds member to group's google group" do
+                  expect(Google::Apis::AdminDirectoryV1::Member)
+                    .to have_received(:new).with(email: Person.last.email,
+                                                 role: GoogleAPI::Roles::MEMBER)
+
+                  expect(directory_service_double)
+                    .to have_received(:insert_member).with(google_group_double.id,
+                                                           google_group_member_double)
+                end
+              end # with google integrations enabled
+            end # submitting email signup form
+          end # viewing email signup form
+        end # picking email path
+
+        describe "picking facebook path" do
+          before { click_link "Join with Facebook" }
+
+          it "navigates to new members form" do
+            current_path.must_equal "/groups/#{group.id}/members/new"
+          end
+
+          it "sets the signup mode to facebook" do
+            current_params['signup_mode'].must_equal 'facebook'
+          end
+
+          it "passes non-sensitive oauth data as cleartext params" do
+            {
+              "provider" => current_params["person[oauth][provider]"],
+              "uid" => current_params["person[oauth][uid]"],
+              "credentials" => {
+                # omit token from this test
+                "expires_at" => current_params["person[oauth][credentials][expires_at]"],
+                "expires" => current_params["person[oauth][credentials][expires]"],
+              },
+              "info" => {
+                "email" => current_params["person[oauth][info][email]"],
+                "name" => current_params["person[oauth][info][name]"],
+                "image" => current_params["person[oauth][info][image]"],
+              }
+            }.must_equal(
+              mock_facebook_auth.to_hash.merge(
+                "credentials" => mock_facebook_auth
+                                   .to_hash
+                                   .fetch('credentials')
+                                   .except('token')
+              )
+            )
+          end
+
+          it "passes oauth token as encrypted param" do
+            Crypto.decrypt_with_nacl_secret(
+              current_params["person[oauth][credentials][token]"]
+            ).must_equal mock_facebook_auth.dig('credentials', 'token')
+          end
+
+          describe "viewing facebook signup form" do
+
+            let(:submissions_by_input_label) do
+              {'Zip Code*'   => '11111',
+               'Phone'       => '111-111-1111',}
+            end
+            let(:labels){ submissions_by_input_label.keys }
+            let(:required_labels){ labels.select{ |l| l.include?("*") } }
+            let(:supressed_fields) do
+              ['Email*', 'Password*', 'Fist Name*', 'Last Name*']
+            end
+
+            it "has fields for missing contact info" do
+              labels.each do |label|
+                page.find("input[placeholder='#{label}']").wont_be_nil
+              end
+            end
+
+            it "has correct required fields" do
+              required_labels.each do |label|
+                "input[placeholder='#{label}'][required='required']"
+              end
+            end
+
+            it "does not show suppressed fields" do
+              supressed_fields.each do |label|
+                page.all("input[placeholder='#{label}']").must_be_empty
+              end
+            end
+
+            describe "filling out facebook signup form" do
+              # we don't test for submission errors here: covered in email branch
+              let(:person_count){ Person.count }
+              let(:membership_count){ Membership.count }
+              let(:identity_count){ Identity.count }
+
+              describe "with no errrors" do
+                before do
+                  person_count; membership_count; identity_count
+                  stub_long_lived_access_token_response.call
+                  fill_out_form submissions_by_input_label
+                  click_button 'Submit'
+                end
+
+                it "creates a new person" do
+                  Person.count.must_equal person_count + 1
+                end
+
+                it "creates a new membership" do
+                  Membership.count.must_equal membership_count + 1
+                end
+
+                it "creates a new identity" do
+                  Identity.count.must_equal identity_count + 1
+                end
+
+                it "stores persons's contact info" do
+                  [:email_addresses, :phone_numbers, :personal_addresses].each do |msg|
+                    Person.last.send(msg).first.primary?.must_equal true
+                  end
+                end
+
+                it "stores person's facebook identity" do
+                  Identity.last.attributes.slice('uid', 'provider', 'access_token')
+                    .must_equal('uid'          => mock_facebook_auth['uid'],
+                                'provider'     => mock_facebook_auth['provider'],
+                                'access_token' => mock_facebook_auth['credentials']['token'])
+                end
+
+                it "redirects to member homepage" do
+                  current_path.must_equal "/home"
+                end
+              end # with no errors
+
+              describe "with invalid inputs" do
+                before do
+                  fill_out_form(
+                    submissions_by_input_label.merge(
+                      'Zip Code*' => 'invalid',
+                      'Phone'     => 'invalid',
+                    )
+                  )
+                  click_button "Submit"
+                end
+
+                it "shows an error for invalid phone number" do
+                  page.must_have_content(
+                    "Phone number 'invalid' is not a valid phone number"
+                  )
+                end
+
+                it "shows an error for invalid postal code" do
+                  page.must_have_content(
+                    "Zip code 'invalid' is not a valid zip code"
+                  )
+                end
+              end # with invalid inputs
+            end # filling out facebook signup form
+          end # viewing facebook signup form
+        end # picking facebook path
+
+        describe "picking google path" do
+
+          before { click_link "Join with Google" }
+
+          it "navigates to new members form" do
+            current_path.must_equal "/groups/#{group.id}/members/new"
+          end
+
+          it "sets the signup mode to google" do
+            current_params['signup_mode'].must_equal 'google'
+          end
+
+          it "passes non-sensitive oauth data as cleartext params" do
+            {
+              "provider" => current_params["person[oauth][provider]"],
+              "uid" => current_params["person[oauth][uid]"],
+              "credentials" => {
+                # omit token from this test
+                "expires_at" => current_params["person[oauth][credentials][expires_at]"],
+                "expires" => current_params["person[oauth][credentials][expires]"],
+              },
+              "info" => {
+                "email" => current_params["person[oauth][info][email]"],
+                "name" => current_params["person[oauth][info][name]"],
+                "image" => current_params["person[oauth][info][image]"],
+              }
+            }.must_equal(
+              mock_google_auth.to_hash.merge(
+                "credentials" => mock_google_auth
+                                   .to_hash
+                                   .fetch('credentials')
+                                   .except('token')
+              )
+            )
+          end
+
+          it "passes oauth token as encrypted param" do
+            Crypto.decrypt_with_nacl_secret(
+              current_params["person[oauth][credentials][token]"]
+            ).must_equal mock_google_auth.dig('credentials', 'token')
+          end
+
+          describe "viewing google signup form" do
+
+            let(:submissions_by_input_label) do
+              {'Zip Code*'   => '11111',
+               'Phone'       => '111-111-1111',}
+            end
+            let(:labels){ submissions_by_input_label.keys }
+            let(:required_labels){ labels.select{ |l| l.include?("*") } }
+            let(:supressed_fields) do
+              ['Email*', 'Password*', 'Fist Name*', 'Last Name*']
+            end
+
+            it "has fields for missing contact info" do
+              labels.each do |label|
+                page.find("input[placeholder='#{label}']").wont_be_nil
+              end
+            end
+
+            it "has correct required fields" do
+              required_labels.each do |label|
+                "input[placeholder='#{label}'][required='required']"
+              end
+            end
+
+            it "does not show suppressed fields" do
+              supressed_fields.each do |label|
+                page.all("input[placeholder='#{label}']").must_be_empty
+              end
+            end
+
+            describe "filling out google signup form" do
+              # we don't test for submission errors here: covered in email branch
+              let(:person_count){ Person.count }
+              let(:membership_count){ Membership.count }
+              let(:identity_count){ Identity.count }
+
+              describe "with no errrors" do
+                before do
+                  person_count; membership_count; identity_count
+                  fill_out_form submissions_by_input_label
+                  click_button 'Submit'
+                end
+
+                it "creates a new person" do
+                  Person.count.must_equal person_count + 1
+                end
+
+                it "creates a new membership" do
+                  Membership.count.must_equal membership_count + 1
+                end
+
+                it "does creates a new identity" do
+                  Identity.count.must_equal identity_count + 1
+                end
+
+                it "stores persons's contact info" do
+                  [:email_addresses, :phone_numbers, :personal_addresses].each do |msg|
+                    Person.last.send(msg).first.primary?.must_equal true
+                  end
+                end
+
+                it "stores person's google identity" do
+                  Identity.last.attributes.slice('uid', 'provider', 'access_token')
+                    .must_equal('uid'          => mock_google_auth['uid'],
+                                'provider'     => mock_google_auth['provider'],
+                                'access_token' => mock_google_auth['credentials']['token'])
+                end
+
+                it "redirects to member homepage" do
+                  current_path.must_equal "/home"
+                end
+              end # with no errors
+
+              describe "with invalid inputs" do
+                before do
+                  fill_out_form(
+                    submissions_by_input_label.merge(
+                      'Zip Code*' => 'invalid',
+                      'Phone'     => 'invalid',
+                    )
+                  )
+                  click_button "Submit"
+                end
+
+                it "shows an error for invalid phone number" do
+                  page.must_have_content(
+                    "Phone number 'invalid' is not a valid phone number"
+                  )
+                end
+
+                it "shows an error for invalid postal code" do
+                  page.must_have_content(
+                    "Zip code 'invalid' is not a valid zip code"
+                  )
+                end
+              end # with invalid inputs
+            end # filling out google signup form
+          end # viewing google signup form
+        end # picking google path
+      end # viewing the join page
+    end # as a first time user
+
+    describe "as user with an affinity account" do
+      before do
+        OmniAuth.config.mock_auth[:facebook] = mock_facebook_auth_existing_user
+        OmniAuth.config.mock_auth[:google_oauth2] = mock_google_auth_existing_user
+        visit "/groups/#{group.id}/join"
+      end
+
+      describe "picking facebook path" do
+        let(:person_count){ Person.count }
+        let(:membership_count){ Membership.count }
+        let(:identity_count){ Identity.count }
+
+        before do
+          person_count; membership_count; identity_count
+          stub_long_lived_access_token_response.call
+          click_link "Join with Facebook"
+          fill_out_form({'Zip Code*'   => '11111',
+                         'Phone'       => '111-111-1111',})
+          click_button "Submit"
+        end
+
+        it "does not create a new person" do
+          Person.count.must_equal person_count
+        end
+
+        it "creates a new membership" do
+          Membership.count.must_equal membership_count + 1
+        end
+
+        it "creates a new identity" do
+          Identity.count.must_equal identity_count + 1
+        end
+
+        it "does not change person's name" do
+          organizer.given_name.must_equal("Test")
+        end
+
+        it "stores persons's contact info" do
+          [:email_addresses, :phone_numbers, :personal_addresses].each do |msg|
+            organizer.send(msg).first.primary?.must_equal true
+          end
+        end
+
+        it "stores person's facebook identity" do
+          Identity.last.attributes.slice('person_id', 'uid', 'provider', 'access_token')
+            .must_equal('person_id'    => organizer.id,
+                        'uid'          => mock_facebook_auth['uid'],
+                        'provider'     => mock_facebook_auth['provider'],
+                        'access_token' => mock_facebook_auth['credentials']['token'])
+        end
+
+        it "redirects to member homepage" do
+          current_path.must_equal "/home"
+        end
+      end # picking facebook path
+    end # as user with an affinity account
+  end # logged out
 end # JoinGroupTest

--- a/test/feature/join_group_test.rb
+++ b/test/feature/join_group_test.rb
@@ -1,9 +1,6 @@
 require_relative "../test_helper"
 
 class JoinGroupTest < FeatureTest
-  let(:group){ groups(:fantastic_four) }
-  let(:organizer){ people(:organizer) }
-
   # facebook fixtures
   let(:facebook_token) do
     "UwlcA5KfBMIfSXx8dYmTusAs5FNmqBDQ13L6upHh84mBua5TR7sK7eGYm9FSGz6pTdfv7xzz"+
@@ -165,82 +162,6 @@ class JoinGroupTest < FeatureTest
     # basic fixtures
     let(:group){ groups(:fantastic_four) }
     let(:organizer){ people(:organizer) }
-
-    # facebook fixtures
-    let(:fb_token) do
-      "UwlcA5KfBMIfSXx8dYmTusAs5FNmqBDQ13L6upHh84mBua5TR7sK7eGYm9FSGz6pTdfv7xzz"+
-        "iIKnPQLOEEw6icFuIFjrjSxQxHfxLpQEYWgz6zzs2U209liTg5JFRm9u7RmRzpxEaaWI9M"+
-        "9u61CAh7psEMkjqsfRBFi4hm89iJ91tACuiQGxtZhKr"
-    end
-    let(:mock_facebook_auth) do
-      OmniAuth::AuthHash.new(
-        { "provider"     => "facebook",
-          "uid"          => "100174124183958",
-          "credentials"  =>
-          { "token"        => fb_token ,
-            "expires_at"   => "1529880563",
-            "expires"      => "true" },
-          "info"         =>
-          { "email"        => "testy@affinity.works",
-            "name"         => "Testy McGee",
-            "image"        => "http://graph.facebook.com/v2.6/"+
-                              "100174124183958/picture" }
-        }
-      )
-    end
-    let(:mock_facebook_auth_existing_user) do
-      mock_facebook_auth.merge(
-        "info" => {
-          "email" => "organizer@admin.com",
-          "name"  => "DifferentlyNamed Organizer",
-          "image" => mock_facebook_auth['image']
-        }
-      )
-    end
-    let(:stub_long_lived_access_token_response) do
-      -> do
-        stub_request(
-          :get,
-          "https://graph.facebook.com/v2.9/oauth/access_token"+
-          "?client_id="+
-          "&client_secret="+
-          "&fb_exchange_token=UwlcA5KfBMIfSXx8dYmTusAs5FNmqBDQ13L6upH"+
-          "h84mBua5TR7sK7eGYm9FSGz6pTdfv7xzziIKnPQLOEEw6icFuIFjrjSxQx"+
-          "HfxLpQEYWgz6zzs2U209liTg5JFRm9u7RmRzpxEaaWI9M9u61CAh7psEMk"+
-          "jqsfRBFi4hm89iJ91tACuiQGxtZhKr&grant_type=fb_exchange_token"
-        ).to_return(:status => 200)
-      end
-    end
-
-    # google fixtures
-    let(:google_token) do
-      "ya29.GluqBT22iW1wYDxF1U295fvAkjpwtOBmp_Yym7rHmj0HIc3KcauH8f4a3Rdkc7SB"+
-        "xcU1h9lUJjeP-PgMpLhGzpoK-W43-Q53UCqMUJjxf82qJEtjm6byTgAILyWn"
-    end
-    let(:mock_google_auth) do
-      OmniAuth::AuthHash.new(
-        { "provider"     => "google",
-          "uid"          => "106985388443100843978",
-          "credentials"  =>
-          { "token"        => google_token ,
-            "expires_at"   => "1524802515",
-            "expires"      => "true" },
-          "info"         =>
-          { "email"        => "testy@affinity.works",
-            "name"         => "Testy McGee",
-            "image"        => "https://lh6.googleusercontent.com/-nw_wxuaEA_0"+
-                              "/AAAAAAAAAAI/AAAAAAAAAAc/jASoGVsZEYI/photo.jpg" },
-        }
-      )
-    end
-    let(:mock_google_auth_existing_user) do
-      mock_google_auth.merge(
-        mock_google_auth.fetch("info").merge(
-          "email" => "organizer@admin.com",
-          "name"  => "Test Organizer",
-        )
-      )
-    end
 
     describe "as a first time user" do
       before do
@@ -514,7 +435,7 @@ class JoinGroupTest < FeatureTest
               describe "with no errrors" do
                 before do
                   person_count; membership_count; identity_count
-                  stub_long_lived_access_token_response.call
+                  stub_long_lived_access_token_request.call
                   fill_out_form submissions_by_input_label
                   click_button 'Submit'
                 end
@@ -619,7 +540,6 @@ class JoinGroupTest < FeatureTest
           end
 
           describe "viewing google signup form" do
-
             let(:submissions_by_input_label) do
               {'Zip Code*'   => '11111',
                'Phone'       => '111-111-1111',}
@@ -649,7 +569,6 @@ class JoinGroupTest < FeatureTest
             end
 
             describe "filling out google signup form" do
-              # we don't test for submission errors here: covered in email branch
               let(:person_count){ Person.count }
               let(:membership_count){ Membership.count }
               let(:identity_count){ Identity.count }
@@ -734,7 +653,7 @@ class JoinGroupTest < FeatureTest
 
         before do
           person_count; membership_count; identity_count
-          stub_long_lived_access_token_response.call
+          stub_long_lived_access_token_request.call
           click_link "Join with Facebook"
           fill_out_form({'Zip Code*'   => '11111',
                          'Phone'       => '111-111-1111',})

--- a/test/feature/join_group_test.rb
+++ b/test/feature/join_group_test.rb
@@ -82,7 +82,27 @@ class JoinGroupTest < FeatureTest
     let(:fantastic_four){ groups(:fantastic_four) }
     let(:ohio_chapter){ groups(:ohio_chapter) }
 
-    before { login_as people(:human_torch) }
+    before { login_as organizer }
+
+    describe "who is already a member of the group" do
+      before do
+        fantastic_four.members.must_include organizer
+        visit "/groups/#{fantastic_four.id}/join"
+      end
+
+      it "does not show a join button" do
+        page.wont_have_button "Join"
+      end
+
+      it "shows a notification that user has already joined" do
+        page.must_have_content "already joined"
+      end
+
+      it "links to group's dashboard" do
+        page.must_have_link fantastic_four.name,
+                            href: "/groups/#{fantastic_four.id}/dashboard"
+      end
+    end
 
     describe "who is not a member of the group" do
       before do

--- a/test/routes/membership_routes_test.rb
+++ b/test/routes/membership_routes_test.rb
@@ -1,0 +1,10 @@
+require_relative "../test_helper"
+
+class MembershipRoutesTest < ActionDispatch::IntegrationTest
+  specify do
+    assert_routing(
+      { path: "/groups/1/memberships", method: :post },
+      { controller: "memberships", action: "create", group_id: "1" }
+    )
+  end
+end


### PR DESCRIPTION
resolves #653 

# Notes
* if a logged-in user doesn't belong to a group:
  * show a "join" button on the join page
  * when they click it, they are added to the group, forwarded to its dashboard
* if a logged-in user *does* belong to a group:
  * show an "already joined" notice
  * link to the dashboard page

# Screenshots

## already-joined view:
![join-group-already-joined](https://user-images.githubusercontent.com/6032844/39555948-ccf3d1ea-4e4a-11e8-858f-3311996acef1.png)

## haven't joined yet view:
![join-page-logged-in](https://user-images.githubusercontent.com/6032844/39555949-cd1124de-4e4a-11e8-924e-c578a4a7055a.png)

## redirect after joining:
![join-group-after-click](https://user-images.githubusercontent.com/6032844/39555947-ccca5482-4e4a-11e8-81cf-4fe2cc19056f.png)