### PR TITLE
resolve "[#644] handle subgroup creation for logged-in user"

### DIFF
--- a/app/assets/stylesheets/create_group_form.scss
+++ b/app/assets/stylesheets/create_group_form.scss
@@ -23,57 +23,63 @@ $primaryblue: rgba(2, 117, 216, 1);
     }
     .form-container {
         display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-        .fields-container {
-            /* background-color: $lightgray; */
-            padding: 1em;
-        }
-        // TODO: extract this!
-        .field {
+        flex-direction: column;
+        .inputs-container {
             display: flex;
-            flex-direction: column;
-            margin-top: .75em;
-            input, textarea {
-                border: 1px solid $lightgray;
-                border-radius: .25em;
-                padding: .5em;
+            flex-direction: row;
+            flex-wrap: wrap;
+            .fields-container {
+                /* background-color: $lightgray; */
+                padding: 1em;
             }
-            textarea {
-                min-height: 13em;
-            }
-        }
-        .group-input-container {
-            @extend .fields-container;
-            display: flex;
-            flex-direction: column;
-            min-width: 67%;
-            flex-grow: 2;
-            padding-right: 1em;
-            .group-inputs {
+            // TODO: extract this!
+            .field {
                 display: flex;
                 flex-direction: column;
+                margin-top: .75em;
+                input, textarea {
+                    border: 1px solid $lightgray;
+                    border-radius: .25em;
+                    padding: .5em;
+                }
+                textarea {
+                    min-height: 13em;
+                }
             }
-        }
-        .organizer-input-container {
-            @extend .fields-container;
-            display: flex;
-            flex-direction: column;
-            flex-grow: 1;
-            min-width: 33%;
-            .organizer-inputs {
+            .group-input-container {
+                @extend .fields-container;
                 display: flex;
                 flex-direction: column;
+                min-width: 67%;
+                flex-grow: 2;
+                padding-right: 1em;
+                .group-inputs {
+                    display: flex;
+                    flex-direction: column;
+                }
+            }
+            .organizer-input-container {
+                @extend .fields-container;
+                display: flex;
+                flex-direction: column;
+                flex-grow: 1;
+                min-width: 33%;
+                .organizer-inputs {
+                    display: flex;
+                    flex-direction: column;
+                }
+            }
+            .organizer-input-container-hidden {
+                width: 0%;
+            }
+        }
+        .submit-container {
+            :first-child {
+                width: 25%;
+            }
+            display: flex;
+            flex-direction: row;
+        }
 
-            }
-        }
-        .submit {
-            @extend .btn, .btn-primary;
-            text-align: center;
-            width: 33%;
-            text-transform: uppercase;
-            margin: 1em auto 1em auto;
-            background-color: $primaryblue;
-        }
     }
 }

--- a/app/controllers/subgroups_controller.rb
+++ b/app/controllers/subgroups_controller.rb
@@ -15,7 +15,7 @@ class SubgroupsController < ApplicationController
     )
     if @subgroup.valid?
       Subgroups::AfterCreate.call(organizer: organizer, subgroup: @subgroup)
-      sign_in_and_redirect(organizer)
+      sign_in_and_redirect_to(organizer, group_dashboard_path(@subgroup))
     else
       render :new
     end
@@ -36,21 +36,19 @@ class SubgroupsController < ApplicationController
   def organizer_params
     params
       .require(:group)
-      .permit(
-        organizer_attributes: [
-          :given_name,
-          :family_name,
-          :password,
-          phone_numbers_attributes: [:number],
-          email_addresses_attributes: [:address],
-          personal_addresses_attributes: [:postal_code]
-        ]
-      )
-      .fetch('organizer_attributes')
-      .tap { |organizer_attrs| format_contact_info(organizer_attrs) }
+      .require(:organizer_attributes)
+      .permit(:id,
+              :given_name,
+              :family_name,
+              :password,
+              phone_numbers_attributes: [:number],
+              email_addresses_attributes: [:address],
+              personal_addresses_attributes: [:postal_code])
+      .tap { |o_params| format_contact_info(o_params) }
   end
 
   def format_contact_info(organizer_attrs)
+    return if current_person # we only gather contact info for logged-out users
     [
       'phone_numbers_attributes',
       'email_addresses_attributes',

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -171,13 +171,18 @@ class Group < ApplicationRecord
   def create_subgroup_with_organizer(subgroup_attrs: {}, organizer_attrs: {})
     subgroup = create_subgroup(
       subgroup_attrs.merge(
-        memberships_attributes: [{
-          person_attributes: organizer_attrs,
-          role: "organizer"
-        }]
+        memberships_attributes: parse_membership_attrs(organizer_attrs)
       )
     )
     [subgroup, subgroup.members.first]
+  end
+
+  def parse_membership_attrs(organizer_attrs)
+    if id = organizer_attrs.fetch('id', nil)
+      [{ person_id: id, role: 'organizer' }]
+    else
+      [{ person_attributes: organizer_attrs, role: 'organizer' }]
+    end
   end
 
   def build_google_group_email

--- a/app/views/subgroups/_organizer_info_logged_in.html.erb
+++ b/app/views/subgroups/_organizer_info_logged_in.html.erb
@@ -1,0 +1,6 @@
+<% organizer = @subgroup.memberships.first.person %>
+<div class="organizer-input-container-hidden">
+  <%= f.fields_for :organizer_attributes, organizer do |member_form| %>
+    <%= member_form.hidden_field :id, value: current_person.id %>
+  <% end %>
+</div>

--- a/app/views/subgroups/_organizer_info_logged_out.html.erb
+++ b/app/views/subgroups/_organizer_info_logged_out.html.erb
@@ -1,0 +1,47 @@
+<div class="organizer-input-container">
+
+  <h2>Organizer Info</h2>
+
+  <% organizer = @subgroup.memberships.first.person %>
+  <% phone_number = organizer.phone_numbers.first %>
+  <% email_address = organizer.email_addresses.first %>
+  <% address = organizer.personal_addresses.first %>
+
+  <div class="organizer-inputs">
+    <%= f.fields_for :organizer_attributes, organizer do |member_form| %>
+      <!-- email -->
+      <div class="field">
+        <%= member_form.fields_for :email_addresses_attributes, email_address do |email_form| %>
+          <%= email_form.text_field :address, placeholder: 'Email', required: true %>
+        <% end #member_form.fields_for :email_address %>
+      </div>
+
+      <!-- password -->
+      <div class="field">
+        <%= member_form.password_field :password, placeholder: :password, required: true %>
+      </div>
+
+      <!-- name -->
+      <div class="field">
+        <%= member_form.text_field :given_name, placeholder: :first_name, required: true %>
+      </div>
+      <div class="field">
+        <%= member_form.text_field :family_name, placeholder: :last_name, required: true %>
+      </div>
+
+      <!-- phone -->
+      <div class="field">
+        <%= member_form.fields_for :phone_numbers_attributes, phone_number do |phone_form| %>
+          <%= phone_form.text_field :number, placeholder: 'Phone number' %>
+        <% end #member_form.fields_for :phone_number %>
+      </div>
+
+      <!-- zip -->
+      <div class="field">
+        <%= member_form.fields_for :personal_addresses_attributes, address do |address_form| %>
+          <%= address_form.text_field :postal_code, placeholder: 'Zipcode (personal)' %>
+        <% end #member_form.fields_for :email_address %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/subgroups/new.html.erb
+++ b/app/views/subgroups/new.html.erb
@@ -23,76 +23,37 @@
       
       <%= form_for @subgroup, url: {action: "create"} do |f| %>
         <div class="form-container">
-          <div class='group-input-container'>
+          <div class="inputs-container">
+            <div class='group-input-container'>
 
-            <h2>Group Info</h2>
+              <h2>Group Info</h2>
 
-            <div class="group-inputs">
+              <div class="group-inputs">
 
-              <div class="field">
-                <%= f.text_field :name, placeholder: :name, required: true %>
-              </div>
-              <div class="field">
-                <%= f.fields_for :location, @subgroup.location do |location_form| %>
-                  <%= location_form.text_field :postal_code, placeholder: 'Zipcode (group)' %>
-                <% end %>
-              </div>
-              <div class="field">
-                <%= f.text_area :description, placeholder: 'Description (may contain HTML)' %>
+                <div class="field">
+                  <%= f.text_field :name, placeholder: :name, required: true %>
+                </div>
+                <div class="field">
+                  <%= f.fields_for :location, @subgroup.location do |location_form| %>
+                    <%= location_form.text_field :postal_code, placeholder: 'Zipcode (group)' %>
+                  <% end %>
+                </div>
+                <div class="field">
+                  <%= f.text_area :description, placeholder: 'Description (may contain HTML)' %>
+                </div>
               </div>
             </div>
+
+            <% if current_person %>
+              <%= render 'organizer_info_logged_in', f: f %>
+            <% else %>
+              <%= render 'organizer_info_logged_out', f: f %>
+            <% end %>
           </div>
 
-          <div class="organizer-input-container">
-
-            <h2>Organizer Info</h2>
-
-            <% organizer = @subgroup.memberships.first.person %>
-            <% phone_number = organizer.phone_numbers.first %>
-            <% email_address = organizer.email_addresses.first %>
-            <% address = organizer.personal_addresses.first %>
-            
-            <div class="organizer-inputs">
-              <%= f.fields_for :organizer_attributes, organizer do |member_form| %>
-                <!-- email -->
-                <div class="field">
-                  <%= member_form.fields_for :email_addresses_attributes, email_address do |email_form| %>
-                    <%= email_form.text_field :address, placeholder: 'Email', required: true %>
-                  <% end #member_form.fields_for :email_address %>
-                </div>
-
-                <!-- password -->
-                <div class="field">
-                  <%= member_form.password_field :password, placeholder: :password, required: true %>
-                </div>
-
-                <!-- name -->
-                <div class="field">
-                  <%= member_form.text_field :given_name, placeholder: :first_name, required: true %>
-                </div>
-                <div class="field">
-                  <%= member_form.text_field :family_name, placeholder: :last_name, required: true %>
-                </div>
-
-                <!-- phone -->
-                <div class="field">
-                  <%= member_form.fields_for :phone_numbers_attributes, phone_number do |phone_form| %>
-                    <%= phone_form.text_field :number, placeholder: 'Phone number' %>  
-                  <% end #member_form.fields_for :phone_number %>
-                </div>
-
-                <!-- zip -->
-                <div class="field">
-                  <%= member_form.fields_for :personal_addresses_attributes, address do |address_form| %>
-                    <%= address_form.text_field :postal_code, placeholder: 'Zipcode (personal)' %>
-                  <% end #member_form.fields_for :email_address %>
-                </div>
-              <% end %>
-            </div>
+          <div class="submit-container">
+            <%= f.submit "Submit", class: "btn-submit"%>
           </div>
-
-          <%= f.submit "Submit", class: "submit"%>
-
         </div>
       <% end # form_for %>
       

--- a/test/feature/create_group_test.rb
+++ b/test/feature/create_group_test.rb
@@ -1,274 +1,330 @@
 require_relative "../test_helper"
 require 'minitest/mock'
 
-class SubgroupCreation < FeatureTest
-
-  let(:group){ groups(:one) }
+class CreateGroupTest < FeatureTest
+  # shared fixtures
   RESOURCES = %w[group address person membership phone_number email_address].freeze
+  let(:group){ groups(:one) }
+  let(:group_count){ Group.count }
+  let(:address_count){ Address.count }
+  let(:person_count){ Person.count }
+  let(:phone_number_count){ PhoneNumber.count }
+  let(:email_address_count){ EmailAddress.count }
+  let(:membership_count){ Membership.count }
+  let(:signup_form_count){ SignupForm.count }
+  let(:last_person){ Person.last }
+  let(:deliveries_count){ ActionMailer::Base.deliveries.size }
 
-  before { visit "/groups/#{group.id}/subgroups/new" }
+  describe "for logged-out person" do
+    before { visit "/groups/#{group.id}/subgroups/new" }
 
-  describe "viewing group creation form" do
-    it "has parent group's name in title" do
-      page.must_have_content group.name
-    end
-
-    it "has fields for creating a group" do
-      ['Name', 'Zipcode (group)'].each do |label|
-        page.find("input[placeholder='#{label}']").wont_be_nil
+    describe "viewing group creation form" do
+      it "has parent group's name in title" do
+        page.must_have_content group.name
       end
-    end
 
-    it "has a large description text area for group" do
-      page.find(
-        "textarea[placeholder='Description (may contain HTML)']"
-      ).wont_be_nil
-    end
-
-    it "has correct required group fields" do
-      page.find("input[placeholder='Name'][required='required']").wont_be_nil
-    end
-
-    it "has groups for creating an organizer" do
-      [
-        'First name',
-        'Last name',
-        'Password',
-        'Email',
-        'Phone number',
-        'Zipcode (personal)',
-      ].each do |label|
-        page.find("input[placeholder='#{label}']").wont_be_nil
-      end
-    end
-
-    it "has correct required organizer fields" do
-      ['Email', 'Password', 'First Name', 'Last Name'].each do |label|
-        "input[placeholder='#{label}'][required='required']"
-      end
-    end
-  end
-
-  describe "submitting form" do
-    let(:group_count){ Group.count }
-    let(:address_count){ Address.count }
-    let(:person_count){ Person.count }
-    let(:phone_number_count){ PhoneNumber.count }
-    let(:email_address_count){ EmailAddress.count }
-    let(:membership_count){ Membership.count }
-    let(:signup_form_count){ SignupForm.count }
-    let(:last_person){ Person.last }
-    let(:deliveries_count){ ActionMailer::Base.deliveries.size }
-
-    describe "with no errors" do
-      before do
-        RESOURCES.each { |r| send("#{r}_count") }
-        deliveries_count
-        perform_enqueued_jobs do
-          fill_out_form(
-            'Name' => 'Jawbreaker',
-            'Description (may contain HTML)' => 'I want to be a boat, I want to learn to swim',
-            'Zipcode (group)' => '90210',
-            'First name' => 'herbert',
-            'Last name' => 'stencil',
-            'Password' => 'password',
-            'Phone number' => '212-867-5309',
-            'Email' => 'foo@bar.com',
-            'Zipcode (personal)' => '90211'
-          )
-          click_button "Submit"
+      it "has fields for creating a group" do
+        ['Name', 'Zipcode (group)'].each do |label|
+          page.find("input[placeholder='#{label}']").wont_be_nil
         end
       end
 
-      RESOURCES.each do |resource|
-        it "creates new #{resource}(s)" do
-          if resource === "address"
-            Address.count.must_equal(address_count + 2)
-          else
-            resource.camelize.constantize.count.must_equal(
-              send("#{resource}_count") + 1
+      it "has a large description text area for group" do
+        page.find(
+          "textarea[placeholder='Description (may contain HTML)']"
+        ).wont_be_nil
+      end
+
+      it "has correct required group fields" do
+        page.find("input[placeholder='Name'][required='required']").wont_be_nil
+      end
+
+      it "has groups for creating an organizer" do
+        [
+          'First name',
+          'Last name',
+          'Password',
+          'Email',
+          'Phone number',
+          'Zipcode (personal)',
+        ].each do |label|
+          page.find("input[placeholder='#{label}']").wont_be_nil
+        end
+      end
+
+      it "has correct required organizer fields" do
+        ['Email', 'Password', 'First Name', 'Last Name'].each do |label|
+          "input[placeholder='#{label}'][required='required']"
+        end
+      end
+    end
+
+    describe "submitting form" do
+
+      describe "with no errors" do
+        before do
+          RESOURCES.each { |r| send("#{r}_count") }
+          deliveries_count
+          perform_enqueued_jobs do
+            fill_out_form(
+              'Name' => 'Jawbreaker',
+              'Description (may contain HTML)' => 'I want to be a boat, I want to learn to swim',
+              'Zipcode (group)' => '90210',
+              'First name' => 'herbert',
+              'Last name' => 'stencil',
+              'Password' => 'password',
+              'Phone number' => '212-867-5309',
+              'Email' => 'foo@bar.com',
+              'Zipcode (personal)' => '90211'
             )
+            click_button "Submit"
           end
         end
-      end
 
-      it "redirects to the user's profile page" do
-        page.current_path.must_equal "/home"
-        page.must_have_content "Welcome"
-      end
-
-      it "saves group info" do
-        Group.last.attributes.slice(*%w[name description]).must_equal(
-          'name' =>  "Jawbreaker",
-          'description' => 'I want to be a boat, I want to learn to swim'
-        )
-      end
-
-      it "saves group location"  do
-        Group.last.location.postal_code.must_equal "90210"
-      end
-
-      it "saves organizer info" do
-        Person.last.attributes.slice(*%w[given_name family_name]).must_equal(
-          'given_name' => 'herbert',
-          'family_name' => 'stencil'
-        )
-      end
-
-      it "saves organizer password" do
-        last_person.encrypted_password.wont_be_nil
-        last_person.valid_password?("password")
-      end
-
-      it "saves organizer contact info" do
-        last_person.email_addresses.last.address.must_equal 'foo@bar.com'
-        last_person.phone_numbers.last.number.must_equal '212-867-5309'
-        last_person.personal_addresses.last.postal_code.must_equal '90211'
-      end
-
-      it "saves contact infos as 'primary'" do
-        last_person.primary_email_address.must_equal 'foo@bar.com'
-        last_person.primary_phone_number.must_equal '212-867-5309'
-        last_person.primary_personal_address.postal_code.must_equal '90211'
-      end
-
-      it "sends a welcome email (asynchronously)" do
-        ActionMailer::Base
-          .deliveries.size.must_equal(deliveries_count + 1)
-      end
-    end
-
-    describe "with errors" do
-      before do
-        RESOURCES.each { |r| send("#{r}_count") }
-        fill_out_form({})
-        click_button "Submit"
-      end
-
-      it "does not create any resources" do
         RESOURCES.each do |resource|
-          resource.camelize.constantize.count.must_equal(send("#{resource}_count"))
+          it "creates new #{resource}(s)" do
+            if resource === "address"
+              Address.count.must_equal(address_count + 2)
+            else
+              resource.camelize.constantize.count.must_equal(
+                send("#{resource}_count") + 1
+              )
+            end
+          end
+        end
+
+        it "redirects to the group's dashboard" do
+          page.current_path.must_equal "/groups/#{Group.last.id}/dashboard"
+        end
+
+        it "saves group info" do
+          Group.last.attributes.slice(*%w[name description]).must_equal(
+            'name' =>  "Jawbreaker",
+            'description' => 'I want to be a boat, I want to learn to swim'
+          )
+        end
+
+        it "saves group location"  do
+          Group.last.location.postal_code.must_equal "90210"
+        end
+
+        it "saves organizer info" do
+          Person.last.attributes.slice(*%w[given_name family_name]).must_equal(
+            'given_name' => 'herbert',
+            'family_name' => 'stencil'
+          )
+        end
+
+        it "saves organizer password" do
+          last_person.encrypted_password.wont_be_nil
+          last_person.valid_password?("password")
+        end
+
+        it "saves organizer contact info" do
+          last_person.email_addresses.last.address.must_equal 'foo@bar.com'
+          last_person.phone_numbers.last.number.must_equal '212-867-5309'
+          last_person.personal_addresses.last.postal_code.must_equal '90211'
+        end
+
+        it "saves contact infos as 'primary'" do
+          last_person.primary_email_address.must_equal 'foo@bar.com'
+          last_person.primary_phone_number.must_equal '212-867-5309'
+          last_person.primary_personal_address.postal_code.must_equal '90211'
+        end
+
+        it "sends a welcome email (asynchronously)" do
+          ActionMailer::Base
+            .deliveries.size.must_equal(deliveries_count + 1)
         end
       end
 
-      it "displays errors" do
-        page.must_have_content "error"
-      end
-    end
-
-    describe "with google group integration enabled" do
-      let(:fancy_group){ groups(:ohio_chapter) }
-      let(:google_group_email){ 'ohio-chapter@nationalnetwork.com' }
-      let(:google_group_group_key){ "#{google_group_email}.test-google-a.com" }
-      let(:google_group_url){ "https://groups.google.com/a/nationalnetwork.com/forum/#!forum/ohio-chapter" }
-      let(:authentication_double){ double(Google::Auth::ServiceAccountCredentials) }
-      let(:directory_service_double){ double(Google::Apis::AdminDirectoryV1::DirectoryService)}
-      let(:google_group_double) do
-        double(Google::Apis::AdminDirectoryV1::Group,
-               id: "0279ka6516ngz0s",
-               email: google_group_email
-              )
-      end
-      let(:group_settings_double){ double(Google::Apis::GroupssettingsV1::Groups) }
-      let(:settings_service_double){ double(Google::Apis::GroupssettingsV1::GroupssettingsService) }
-      let(:google_group_member_double){ double(Google::Apis::AdminDirectoryV1::Member)}
-      let(:google_group_count){ GoogleGroup.count }
-
-      before do
-        # authentication
-        allow(Google::Auth::ServiceAccountCredentials)
-          .to receive(:make_creds).and_return(authentication_double)
-        allow(authentication_double)
-          .to receive(:sub=)
-        allow(Google::Auth::ServiceAccountCredentials)
-          .to receive(:sub=)
-
-        # connecting to directory service
-        allow(Google::Apis::AdminDirectoryV1::DirectoryService)
-          .to receive(:new).and_return(directory_service_double)
-        allow(directory_service_double)
-          .to receive(:authorization=)
-
-        # creating group
-        allow(Google::Apis::AdminDirectoryV1::Group)
-          .to receive(:new).and_return(google_group_double)
-        allow(directory_service_double)
-          .to receive(:insert_group).and_return(google_group_double)
-
-        # setting group group permissions
-        allow(Google::Apis::GroupssettingsV1::Groups)
-          .to receive(:new).and_return(group_settings_double)
-        allow(group_settings_double).to receive(:authorization=)
-        allow(Google::Apis::GroupssettingsV1::GroupssettingsService)
-          .to receive(:new).and_return(settings_service_double)
-        allow(settings_service_double).to receive(:authorization=)
-        allow(settings_service_double).to receive(:update_group) # <- expect!
-
-        # adding member
-        allow(Google::Apis::AdminDirectoryV1::Member)
-          .to receive(:new).and_return(google_group_member_double)
-        allow(directory_service_double).to receive(:insert_member)
-
-        # count google groups
-        google_group_count
-
-        # fill out form!
-        visit "/groups/#{fancy_group.id}/subgroups/new"
-        perform_enqueued_jobs do
-          fill_out_form(
-            'Name' => 'Jawbreaker',
-            'Description (may contain HTML)' => 'I want to be a boat, I want to learn to swim',
-            'Zipcode (group)' => '90210',
-            'First name' => 'herbert',
-            'Last name' => 'stencil',
-            'Password' => 'password',
-            'Phone number' => '212-867-5309',
-            'Email' => 'foo@bar.com',
-            'Zipcode (personal)' => '90211'
-          )
+      describe "with errors" do
+        before do
+          RESOURCES.each { |r| send("#{r}_count") }
+          fill_out_form({})
           click_button "Submit"
         end
+
+        it "does not create any resources" do
+          RESOURCES.each do |resource|
+            resource.camelize.constantize.count.must_equal(send("#{resource}_count"))
+          end
+        end
+
+        it "displays errors" do
+          page.must_have_content "error"
+        end
       end
 
-      it "creates a google group" do
-        expect(Google::Apis::AdminDirectoryV1::Group)
-          .to have_received(:new).with(email: Group.last.build_google_group_email,
-                                       name: Group.last.name,
-                                       description: GoogleAPI::CreateGoogleGroup::DESCRIPTION)
+      describe "with google group integration enabled" do
+        let(:fancy_group){ groups(:ohio_chapter) }
+        let(:google_group_email){ 'ohio-chapter@nationalnetwork.com' }
+        let(:google_group_group_key){ "#{google_group_email}.test-google-a.com" }
+        let(:google_group_url){ "https://groups.google.com/a/nationalnetwork.com/forum/#!forum/ohio-chapter" }
+        let(:authentication_double){ double(Google::Auth::ServiceAccountCredentials) }
+        let(:directory_service_double){ double(Google::Apis::AdminDirectoryV1::DirectoryService)}
+        let(:google_group_double) do
+          double(Google::Apis::AdminDirectoryV1::Group,
+                 id: "0279ka6516ngz0s",
+                 email: google_group_email
+                )
+        end
+        let(:group_settings_double){ double(Google::Apis::GroupssettingsV1::Groups) }
+        let(:settings_service_double){ double(Google::Apis::GroupssettingsV1::GroupssettingsService) }
+        let(:google_group_member_double){ double(Google::Apis::AdminDirectoryV1::Member)}
+        let(:google_group_count){ GoogleGroup.count }
 
-        expect(directory_service_double)
-          .to have_received(:insert_group).with(google_group_double)
-      end
+        before do
+          # authentication
+          allow(Google::Auth::ServiceAccountCredentials)
+            .to receive(:make_creds).and_return(authentication_double)
+          allow(authentication_double)
+            .to receive(:sub=)
+          allow(Google::Auth::ServiceAccountCredentials)
+            .to receive(:sub=)
 
-      it "adds permissive settings to google group" do
-        expect(settings_service_double)
-          .to have_received(:update_group).with(google_group_email,
-                                                group_settings_double)
-      end
+          # connecting to directory service
+          allow(Google::Apis::AdminDirectoryV1::DirectoryService)
+            .to receive(:new).and_return(directory_service_double)
+          allow(directory_service_double)
+            .to receive(:authorization=)
 
-      it "adds member to google group" do
-        expect(Google::Apis::AdminDirectoryV1::Member)
-          .to have_received(:new).with(email: Person.last.email,
-                                       role: GoogleAPI::Roles::OWNER)
+          # creating group
+          allow(Google::Apis::AdminDirectoryV1::Group)
+            .to receive(:new).and_return(google_group_double)
+          allow(directory_service_double)
+            .to receive(:insert_group).and_return(google_group_double)
 
-        expect(directory_service_double)
-          .to have_received(:insert_member).with(google_group_double.id,
-                                                 google_group_member_double)
-      end
+          # setting group group permissions
+          allow(Google::Apis::GroupssettingsV1::Groups)
+            .to receive(:new).and_return(group_settings_double)
+          allow(group_settings_double).to receive(:authorization=)
+          allow(Google::Apis::GroupssettingsV1::GroupssettingsService)
+            .to receive(:new).and_return(settings_service_double)
+          allow(settings_service_double).to receive(:authorization=)
+          allow(settings_service_double).to receive(:update_group) # <- expect!
 
-      it "stores a record of the new google group" do
-        GoogleGroup.count.must_equal(google_group_count + 1)
-      end
+          # adding member
+          allow(Google::Apis::AdminDirectoryV1::Member)
+            .to receive(:new).and_return(google_group_member_double)
+          allow(directory_service_double).to receive(:insert_member)
 
-      it "saves the google group's important attributes" do
-        GoogleGroup.last.attributes.slice(*%w[group_id group_key email url])
-          .must_equal(
-            'group_id'  => Group.last.id,
-            'group_key' => google_group_double.id,
-            'email'     => google_group_email,
-            'url'       => google_group_url
-          )
+          # count google groups
+          google_group_count
+
+          # fill out form!
+          visit "/groups/#{fancy_group.id}/subgroups/new"
+          perform_enqueued_jobs do
+            fill_out_form(
+              'Name' => 'Jawbreaker',
+              'Description (may contain HTML)' => 'I want to be a boat, I want to learn to swim',
+              'Zipcode (group)' => '90210',
+              'First name' => 'herbert',
+              'Last name' => 'stencil',
+              'Password' => 'password',
+              'Phone number' => '212-867-5309',
+              'Email' => 'foo@bar.com',
+              'Zipcode (personal)' => '90211'
+            )
+            click_button "Submit"
+          end
+        end
+
+        it "creates a google group" do
+          expect(Google::Apis::AdminDirectoryV1::Group)
+            .to have_received(:new).with(email: Group.last.build_google_group_email,
+                                         name: Group.last.name,
+                                         description: GoogleAPI::CreateGoogleGroup::DESCRIPTION)
+
+          expect(directory_service_double)
+            .to have_received(:insert_group).with(google_group_double)
+        end
+
+        it "adds permissive settings to google group" do
+          expect(settings_service_double)
+            .to have_received(:update_group).with(google_group_email,
+                                                  group_settings_double)
+        end
+
+        it "adds member to google group" do
+          expect(Google::Apis::AdminDirectoryV1::Member)
+            .to have_received(:new).with(email: Person.last.email,
+                                         role: GoogleAPI::Roles::OWNER)
+
+          expect(directory_service_double)
+            .to have_received(:insert_member).with(google_group_double.id,
+                                                   google_group_member_double)
+        end
+
+        it "stores a record of the new google group" do
+          GoogleGroup.count.must_equal(google_group_count + 1)
+        end
+
+        it "saves the google group's important attributes" do
+          GoogleGroup.last.attributes.slice(*%w[group_id group_key email url])
+            .must_equal(
+              'group_id'  => Group.last.id,
+              'group_key' => google_group_double.id,
+              'email'     => google_group_email,
+              'url'       => google_group_url
+            )
+        end
+      end # with google group integration enabled
+    end # submitting form
+  end # for logged-out person
+
+  describe "for logged-in person" do
+    let(:person){ people(:human_torch) }
+    before do
+      login_as person
+      visit "/groups/#{group.id}/subgroups/new"
+    end
+
+    describe "viewing page" do
+      it "should not show organizer info fields" do
+        page.wont_have_content "Organizer Info"
       end
     end
-  end
-end
+
+    describe "filling out form" do
+      describe "with no errors" do
+        before do
+          RESOURCES.each { |r| send("#{r}_count") }
+          deliveries_count
+          perform_enqueued_jobs do
+            fill_out_form(
+              'Name' => 'Jawbreaker',
+              'Description (may contain HTML)' => 'I want to be a boat',
+              'Zipcode (group)' => '90210'
+            )
+            click_button "Submit"
+          end
+        end
+
+        it "creates new subgroup" do
+          Group.count.must_equal group_count + 1
+        end
+
+        it "makes subgroup an affiliate of parent group" do
+          group.affiliates.must_include Group.last
+        end
+
+        it "does not create new person" do
+          Person.count.must_equal person_count
+        end
+
+        it "makes person a member of subgroup" do
+          Group.last.members.must_include person
+        end
+
+        it "redirects to subgroup's dashboard" do
+          current_path.must_equal "/groups/#{Group.last.id}/dashboard"
+        end
+
+        it "sends a welcome email" do
+          ActionMailer::Base.deliveries.size.must_equal deliveries_count + 1
+        end
+      end # with no errors
+    end # filling out form
+  end # for logged-in person
+end # CreateGroupTest


### PR DESCRIPTION
resolves #644 
________________________

# Functionality

* don't show organizer info fields
* on submit:
  * make logged-in person organizer of new subgroup
  * make them part of google group, send them welcome email
  * redirect them to the subgroup's dashboard page
* BONUS: now also redirect *anyone* who just created a subgroup to its dashboard (smoother UX, and shows that the thing they just did actually worked)

# Screengrabs

**filling out subgroup creation form:**
![create-group-logged-in](https://user-images.githubusercontent.com/6032844/39837857-99eb9d36-53a5-11e8-8696-161cb721e33b.png)


**after submitting subgroup creation form:**
![create-group-after-submit](https://user-images.githubusercontent.com/6032844/39837848-9597212e-53a5-11e8-9297-8145eb43a0d8.png)
