### PR TITLE
resolve "[#665] add flow to create group w/ email signup for logged-out users"

### DIFF
--- a/app/assets/stylesheets/create_group_form.scss
+++ b/app/assets/stylesheets/create_group_form.scss
@@ -73,12 +73,13 @@ $primaryblue: rgba(2, 117, 216, 1);
                 width: 0%;
             }
         }
-        .submit-container {
-            :first-child {
-                width: 25%;
-            }
+        .create-buttons-container {
             display: flex;
-            flex-direction: row;
+            flex-direction: column;
+            align-items: center;
+            button {
+                width: 33%;
+            }
         }
 
     }

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -43,7 +43,7 @@ class MembersController < ApplicationController
   # GET /groups/:id/members/new
   def new
     if is_signup_form?
-      render "signup_form_#{@signup_mode}"
+      render "signup_form_#{@signup_mode}", layout: "signup"
     else
       authorize! :manage, @group # dupe of authorize_group_access? (@aguestuser)
     end
@@ -69,7 +69,7 @@ class MembersController < ApplicationController
   # GET /groups/:id/members/1/edit
   def edit
     if is_signup_form?
-      render "signup_form_#{@signup_mode}"
+      render "signup_form_#{@signup_mode}", layout: "signup"
     else
       @groups = Group.all
       authorize! :manage, @group # redundant? (@aguestuser)
@@ -318,8 +318,14 @@ class MembersController < ApplicationController
 
   def handle_create_error(fmt)
     build_member_resources
-    fmt.html { render is_signup_form? ? "signup_form_#{@signup_mode}" : :new }
     fmt.json { render json: @group.errors, status: :unprocessable_entity }
+    fmt.html do
+      if is_signup_form?
+        render "signup_form_#{@signup_mode}", layout: 'signup'
+      else
+        render :new
+      end
+    end
   end
 
   def handle_update_success(format)

--- a/app/controllers/subgroups_controller.rb
+++ b/app/controllers/subgroups_controller.rb
@@ -1,42 +1,77 @@
 class SubgroupsController < ApplicationController
-
+  SIGNUP_MODES = %w[email google facebook].freeze
   before_action :set_group
+  before_action :set_signup_mode
+  before_action :set_target_action
 
   # GET groups/:group_id/subgroups/new
   def new
     @subgroup = Group.build_group_with_organizer
   end
 
+  # GET groups/:group_id/subgroups/signup
+  def signup
+    @person = Person.build_for_signup
+    @subgroup = JSON.generate(subgroup_params.to_h)
+    render "signup_form_#{@signup_mode}", layout: 'signup'
+  end
+
   # POST groups/:group_id/subgroups
   def create
-    @subgroup, organizer = @group.create_subgroup_with_organizer(
+    @subgroup, @person = @group.create_subgroup_with_organizer(
       subgroup_attrs: subgroup_params,
       organizer_attrs: organizer_params
     )
-    if @subgroup.valid?
-      Subgroups::AfterCreate.call(organizer: organizer, subgroup: @subgroup)
-      sign_in_and_redirect_to(organizer, group_dashboard_path(@subgroup))
-    else
-      render :new
-    end
+    @subgroup.valid? ? handle_create_success : handle_create_error
   end
 
   private
 
+  ###########
+  # SETTERS #
+  ###########
+
   def set_group
-    @group = Group.find(params[:group_id])
+    @group = current_group
   end
 
+  def set_signup_mode
+    @signup_mode = SIGNUP_MODES.dup.delete(params[:signup_mode] ||
+                                           params[:commit])
+  end
+
+  def set_target_action
+    @target_action = (!current_person && action_name == 'new') ?
+                       'signup' :
+                       'create'
+  end
+
+  ##########
+  # PARAMS #
+  ##########
+
   def subgroup_params
-    params
-      .require(:group)
-      .permit(:name, :description, :summary, location_attributes: [:postal_code])
+    deserialize(params.require(:subgroup))
+      .permit(:name,
+              :description,
+              :summary,
+              location_attributes: [:postal_code])
+  end
+
+  def deserialize(maybe_params)
+    case maybe_params
+    when String # ie: string-serialized JSON
+      ActionController::Parameters.new(JSON.parse(maybe_params).to_h)
+    when ActionController::Parameters
+      maybe_params
+    end
   end
 
   def organizer_params
-    params
-      .require(:group)
-      .require(:organizer_attributes)
+    base = params[:person] ?
+             params.require(:person) :
+             params.require(:subgroup).require(:organizer_attributes)
+    base
       .permit(:id,
               :given_name,
               :family_name,
@@ -44,19 +79,46 @@ class SubgroupsController < ApplicationController
               phone_numbers_attributes: [:number],
               email_addresses_attributes: [:address],
               personal_addresses_attributes: [:postal_code])
-      .tap { |o_params| format_contact_info(o_params) }
+       .tap { |prams| format(prams) }
   end
 
-  def format_contact_info(organizer_attrs)
-    return if current_person # we only gather contact info for logged-out users
+  def format(prams)
+    prams
+      .tap { |p| format_contact_info(p) }
+      .tap { |p| handle_empty_contact_info(p) }
+  end
+
+  def format_contact_info(prams)
+    return if current_person # only gather contact info for logged-out users
     [
       'phone_numbers_attributes',
       'email_addresses_attributes',
       'personal_addresses_attributes'
-    ].each do |attrs|
-      organizer_attrs.merge!(
-        attrs => [organizer_attrs.fetch(attrs).merge(primary: true)]
-      )
+    ].each { |collection| prams.dig(collection, '0').merge!(primary: true) }
+  end
+
+  def handle_empty_contact_info(prams)
+    if prams.dig('phone_numbers_attributes', '0', 'number')&.empty?
+      prams.delete('phone_numbers_attributes')
+    end
+  end
+
+  ##########################
+  # ACTION RESULT HANDLERS #
+  ##########################
+
+  def handle_create_success
+    Subgroups::AfterCreate.call(organizer: @person, subgroup: @subgroup)
+    sign_in_and_redirect_to(@person, group_dashboard_path(@subgroup))
+  end
+
+  def handle_create_error
+    if @signup_mode
+      @person = @subgroup.memberships.first.person
+      @subgroup = JSON.generate(subgroup_params.to_h)
+      render "signup_form_#{@signup_mode}", layout: 'signup'
+    else
+      render :new
     end
   end
 end

--- a/app/models/concerns/can_signup.rb
+++ b/app/models/concerns/can_signup.rb
@@ -1,23 +1,22 @@
 module CanSignup
   extend ActiveSupport::Concern
+  RESOURCE_COLLECTIONS = [:email_addresses,
+                          :personal_addresses,
+                          :phone_numbers].freeze
 
   included do
-
-    def signup_resources_for(form)
-      form.nested_input_groups.map { |input_group| send(input_group.resource) }
-    end
-
-    def build_signup_resources_for(form)
-      signup_resources_for(form).each do |resources|
-        resources.build(primary: true) if resources.empty?
+    def build_signup_resources
+      RESOURCE_COLLECTIONS.each do |resource_collection|
+        if send(resource_collection).empty?
+          send(resource_collection).build(primary: true)
+        end
       end
     end
   end
 
   class_methods do
-
-    def build_for_signup(form)
-      Person.new.tap { |p| p.build_signup_resources_for form }
+    def build_for_signup
+      Person.new.tap { |p| p.build_signup_resources }
     end
 
     def create_from_signup(form, group, person_attrs)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,6 @@
   </head>
 
   <body>
-    <%= yield %>
+    <%= content_for?(:application) ? yield(:application) : yield %>
   </body>
 </html>

--- a/app/views/layouts/signup.html.erb
+++ b/app/views/layouts/signup.html.erb
@@ -1,0 +1,11 @@
+<% content_for :application do %>
+  <%= render 'layouts/modal_header' %>
+  <div class="container-html modal-container">
+    <div class="card">
+      <div class="card-block">
+        <%= yield :signup_form %>
+      </div>
+    </div>
+  </div>
+<% end #content_for :application %>
+<%= render template: 'layouts/application' %>

--- a/app/views/members/_signup_form_oauth.html.erb
+++ b/app/views/members/_signup_form_oauth.html.erb
@@ -1,39 +1,37 @@
-<%= render 'layouts/modal_header' %>
-<div class="container-html modal-container">
-  <div class="card">
-    <div class="card-block">
-      <h3>Join <%= @group.name %></h3>
-      <div>
-        <%= form_for @member, as: :person, url: @target do |f| %>
-          <div class="prompt">
-            We just need a little more info...
-          </div>
-
-          <%= render partial: "error_alert" %>
-
-          <%= f.hidden_field :oauth, value: @oauth %>
-
-          <div class="form-group">
-            <%= f.fields_for :personal_addresses do |ff| %>
-              <%= ff.text_field :postal_code, placeholder: 'Zip Code*', required: true, class: 'wide' %>
-              <%= ff.hidden_field :primary, value: true %>
-            <% end # f.fields_for :personal_addresses %>
-          </div>
-
-          <div class="form-group">
-            <%= f.fields_for :phone_numbers do |ff| %>
-              <%= ff.text_field :number, placeholder: 'Phone', class: 'wide' %>
-              <%= ff.hidden_field :primary, value: true %>
-            <% end # f.fields_for :phone_numbers %>
-          </div>
-
-          <div class="actions modal-actions">
-            <%= f.submit "Submit", class: "btn-submit" %>
-            <%= link_to "Cancel", group_join_path(@group),  class: "btn-cancel" %>
-          </div>
-
-        <% end # form_for @member %>
+<% content_for :signup_form do %>
+  <h3>Join <%= @group.name %></h3>
+  <div>
+    <%= form_for @member, as: :person, url: @target do |f| %>
+      <div class="prompt">
+        We just need a little more info...
       </div>
-    </div>
+
+      <!-- errors -->
+      <%= render "shared/signup_error_alert", person: @member %>
+
+      <!-- hidden fields -->
+      <%= f.hidden_field :oauth, value: @oauth %>
+
+      <!-- inputs -->
+      <div class="form-group">
+        <%= f.fields_for :personal_addresses do |ff| %>
+          <%= ff.text_field :postal_code, placeholder: 'Zip Code*', required: true, class: 'wide' %>
+          <%= ff.hidden_field :primary, value: true %>
+        <% end # f.fields_for :personal_addresses %>
+      </div>
+
+      <div class="form-group">
+        <%= f.fields_for :phone_numbers do |ff| %>
+          <%= ff.text_field :number, placeholder: 'Phone', class: 'wide' %>
+          <%= ff.hidden_field :primary, value: true %>
+        <% end # f.fields_for :phone_numbers %>
+      </div>
+
+      <div class="actions modal-actions">
+        <%= f.submit "Submit", class: "btn-submit" %>
+        <%= link_to "Cancel", group_join_path(@group),  class: "btn-cancel" %>
+      </div>
+
+    <% end # form_for @member %>
   </div>
-</div>
+<% end #content_for :signup_form %>

--- a/app/views/members/signup_form_email.html.erb
+++ b/app/views/members/signup_form_email.html.erb
@@ -1,53 +1,16 @@
-<%= render 'layouts/modal_header' %>
-<div class="container-html modal-container">
-  <div class="card">
-    <div class="card-block">
-      <h3>Join <%= @group.name %></h3>
-      <div>
-        <%= form_for @member, as: :person, url: group_members_path(@group, signup_mode: 'email') do |f| %>
-          <%= render partial: "error_alert" %>
-          <%= f.hidden_field :signup_mode, value: 'email'%>
-
-          <div class="form-group mt-3">
-            <%= f.fields_for :email_addresses do |ff| %>
-              <%= ff.text_field :address, placeholder: 'Email*', required: true, class: 'wide' %>
-              <%= ff.hidden_field :primary, value: true %>
-            <% end # f.fields_for :email_addresses %>
-          </div>
-
-          <div class="form-group">
-            <%= f.password_field :password, placeholder: 'Password*', required: true, class: 'wide' %>
-          </div>
-
-          <div class="form-group">
-            <%= f.text_field :given_name, placeholder: 'First Name*', required: true, class: 'wide' %>
-          </div>
-
-          <div class="form-group">
-            <%= f.text_field :family_name, placeholder: 'Last Name*', required: true, class: 'wide' %>
-          </div>
-
-          <div class="form-group">
-            <%= f.fields_for :personal_addresses do |ff| %>
-              <%= ff.text_field :postal_code, placeholder: 'Zip Code*', required: true, class: 'wide' %>
-              <%= ff.hidden_field :primary, value: true %>
-            <% end # f.fields_for :personal_addresses %>
-          </div>
-
-          <div class="form-group">
-            <%= f.fields_for :phone_numbers do |ff| %>
-              <%= ff.text_field :number, placeholder: 'Phone', class: 'wide' %>
-              <%= ff.hidden_field :primary, value: true %>
-            <% end # f.fields_for :phone_numbers %>
-          </div>
-
-          <div class="actions modal-actions">
-            <%= f.submit "Submit", class: "btn-submit" %>
-            <%= link_to "Cancel", group_join_path(@group),  class: "btn-cancel" %>
-          </div>
-
-        <% end # form_for @member %>
+<% content_for :signup_form do %>
+  <h3>Join <%= @group.name %></h3>
+  <div>
+    <%= form_for @member, as: :person, url: group_members_path(@group, signup_mode: 'email') do |f| %>
+      <!-- errors -->
+      <%= render "shared/signup_error_alert", person: @member %>
+      <!-- inputs -->
+      <%= render "shared/signup_fields_email", f: f %>
+      <!-- action buttons -->
+      <div class="actions modal-actions">
+        <%= f.submit "Submit", class: "btn-submit" %>
+        <%= link_to "Cancel", group_join_path(@group),  class: "btn-cancel" %>
       </div>
-    </div>
+    <% end # form_for @member %>
   </div>
-</div>
+<% end #content_for :signup_form%>

--- a/app/views/shared/_modal_actions.html.erb
+++ b/app/views/shared/_modal_actions.html.erb
@@ -1,0 +1,4 @@
+<div class="actions modal-actions">
+  <%= f.submit "Submit", class: "btn-submit" %>
+  <%= link_to "Cancel", cancel_path,  class: "btn-cancel" %>
+</div>

--- a/app/views/shared/_signup_error_alert.html.erb
+++ b/app/views/shared/_signup_error_alert.html.erb
@@ -1,0 +1,11 @@
+<%# locals: person: Person %>
+<% if person.errors.any? %>
+  <div id="error_explanation" class="alert alert-danger" role="alert">
+    <strong><%= pluralize(person.errors.count, "error") %> prevented this person from being saved:</strong>
+    <ul>
+      <% person.errors.full_messages.each do |message| %>
+        <li><%= PersonPresenter.formatted_error message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_signup_fields_email.html.erb
+++ b/app/views/shared/_signup_fields_email.html.erb
@@ -1,0 +1,32 @@
+<div class="form-group mt-3">
+  <%= f.fields_for :email_addresses do |ff| %>
+    <%= ff.text_field :address, placeholder: 'Email*', required: true, class: 'wide' %>
+    <%= ff.hidden_field :primary, value: true %>
+  <% end # f.fields_for :email_addresses %>
+</div>
+
+<div class="form-group">
+  <%= f.password_field :password, placeholder: 'Password*', required: true, class: 'wide' %>
+</div>
+
+<div class="form-group">
+  <%= f.text_field :given_name, placeholder: 'First Name*', required: true, class: 'wide' %>
+</div>
+
+<div class="form-group">
+  <%= f.text_field :family_name, placeholder: 'Last Name*', required: true, class: 'wide' %>
+</div>
+
+<div class="form-group">
+  <%= f.fields_for :personal_addresses do |ff| %>
+    <%= ff.text_field :postal_code, placeholder: 'Zip Code*', required: true, class: 'wide' %>
+    <%= ff.hidden_field :primary, value: true %>
+  <% end # f.fields_for :personal_addresses %>
+</div>
+
+<div class="form-group">
+  <%= f.fields_for :phone_numbers do |ff| %>
+    <%= ff.text_field :number, placeholder: 'Phone', class: 'wide' %>
+    <%= ff.hidden_field :primary, value: true %>
+  <% end # f.fields_for :phone_numbers %>
+</div>

--- a/app/views/subgroups/_organizer_info_logged_out.html.erb
+++ b/app/views/subgroups/_organizer_info_logged_out.html.erb
@@ -39,7 +39,7 @@
       <!-- zip -->
       <div class="field">
         <%= member_form.fields_for :personal_addresses_attributes, address do |address_form| %>
-          <%= address_form.text_field :postal_code, placeholder: 'Zipcode (personal)' %>
+          <%= address_form.text_field :postal_code, placeholder: 'Zip Code (personal)' %>
         <% end #member_form.fields_for :email_address %>
       </div>
     <% end %>

--- a/app/views/subgroups/_submit_logged_in.html.erb
+++ b/app/views/subgroups/_submit_logged_in.html.erb
@@ -4,3 +4,4 @@
     <%= member_form.hidden_field :id, value: current_person.id %>
   <% end %>
 </div>
+<%= f.submit "Submit", class: "btn-submit"%>

--- a/app/views/subgroups/_submit_logged_out.html.erb
+++ b/app/views/subgroups/_submit_logged_out.html.erb
@@ -1,0 +1,6 @@
+<div class="create-buttons-container">
+  <%= f.button(type: 'submit', name: 'commit', value: 'email', class: "btn-email-join") do %>
+    <%= image_tag 'email-icon.svg' %>
+    <span>Create with Email</span>
+  <% end %>
+</div>

--- a/app/views/subgroups/new.html.erb
+++ b/app/views/subgroups/new.html.erb
@@ -20,44 +20,42 @@
           <% end # if @subgroup.errors %>
         </div>
       </div>
-      
-      <%= form_for @subgroup, url: {action: "create"} do |f| %>
+
+      <%= form_for @subgroup, as: :subgroup, url: { action: @target_action } do |f| %>
+
         <div class="form-container">
+
           <div class="inputs-container">
             <div class='group-input-container'>
 
               <h2>Group Info</h2>
 
               <div class="group-inputs">
-
                 <div class="field">
-                  <%= f.text_field :name, placeholder: :name, required: true %>
+                  <%= f.text_field :name, placeholder: 'Name*', required: true %>
                 </div>
                 <div class="field">
                   <%= f.fields_for :location, @subgroup.location do |location_form| %>
-                    <%= location_form.text_field :postal_code, placeholder: 'Zipcode (group)' %>
+                    <%= location_form.text_field :postal_code, placeholder: 'Zip Code' %>
                   <% end %>
                 </div>
                 <div class="field">
-                  <%= f.text_area :description, placeholder: 'Description (may contain HTML)' %>
+                  <%= f.text_area :description, placeholder: 'Description' %>
                 </div>
               </div>
-            </div>
 
-            <% if current_person %>
-              <%= render 'organizer_info_logged_in', f: f %>
-            <% else %>
-              <%= render 'organizer_info_logged_out', f: f %>
-            <% end %>
+            </div>
           </div>
 
           <div class="submit-container">
-            <%= f.submit "Submit", class: "btn-submit"%>
+            <% if current_person %>
+              <%= render 'submit_logged_in', f: f %>
+            <% else %>
+              <%= render 'submit_logged_out', f: f %>
+            <% end %>
           </div>
         </div>
       <% end # form_for %>
-      
     </div>
   </div>
-</div>
 </div>

--- a/app/views/subgroups/signup_form_email.html.erb
+++ b/app/views/subgroups/signup_form_email.html.erb
@@ -1,0 +1,18 @@
+<% content_for :signup_form do %>
+  <h3>Organizer Signup</h3>
+  <div>
+    <div class="prompt">
+      We need some info to create your account...
+    </div>
+    <%= form_for @person, url: { action: @target_action,
+                                 signup_mode: @signup_mode,
+                                 subgroup: @subgroup } do |f| %>
+      <!-- errors -->
+      <%= render "shared/signup_error_alert", person: @person %>
+      <!-- inputs -->
+      <%= render "shared/signup_fields_email", f: f %>
+      <!-- action buttons -->
+      <%= render "shared/modal_actions", f: f, cancel_path: new_group_subgroup_path(current_group) %>
+    <% end # form_for @person %>
+  </div>
+<% end #content_for :signup_form%>

--- a/client/app/bundles/Events/containers/AttendanceForm.jsx
+++ b/client/app/bundles/Events/containers/AttendanceForm.jsx
@@ -67,7 +67,7 @@ class AttendanceForm extends Component {
             />
 
             <Input
-              label='Zipcode:'
+              label='Zip Code:'
               classes='col-md-2'
               value={newAttendance.postal_code}
               onChange={(e) => setAttendanceAttribute('postal_code', e.target.value)}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,7 +66,11 @@ Rails.application.routes.draw do
     get '/dashboard', to: 'dashboard#show', as: 'dashboard'
     get '/join', to: 'groups#join'
 
-    resources :subgroups, only: [:new, :create]
+    resources :subgroups, only: [:new, :create] do
+      collection do
+        post '/signup', to: 'subgroups#signup'
+      end
+    end
 
     resources :signup_forms, only: [] do
       resources :signups, only: %i[new create]

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -22,7 +22,7 @@ namespace :heroku do
   task export_vars: :environment do
     puts "--- Checking for heroku-config plugin"
     plugins = `heroku plugins`
-    
+
     if plugins.include? "heroku-config"
       puts "heroku-config plugin already installed!"
     else

--- a/test/feature/create_group_test.rb
+++ b/test/feature/create_group_test.rb
@@ -19,258 +19,332 @@ class CreateGroupTest < FeatureTest
     before { visit "/groups/#{group.id}/subgroups/new" }
 
     describe "viewing group creation form" do
+      let(:group_values_by_input) do
+        { 'Name*'       => 'Jawbreaker',
+          'Zip Code'    => '90210',
+          'Description' => 'I want to be a boat' }
+      end
+
       it "has parent group's name in title" do
         page.must_have_content group.name
       end
 
       it "has fields for creating a group" do
-        ['Name', 'Zipcode (group)'].each do |label|
+        ['Name*', 'Zip Code'].each do |label|
           page.find("input[placeholder='#{label}']").wont_be_nil
         end
       end
 
       it "has a large description text area for group" do
         page.find(
-          "textarea[placeholder='Description (may contain HTML)']"
+          "textarea[placeholder='Description']"
         ).wont_be_nil
       end
 
       it "has correct required group fields" do
-        page.find("input[placeholder='Name'][required='required']").wont_be_nil
+        page.find("input[placeholder='Name*'][required='required']").wont_be_nil
       end
 
-      it "has groups for creating an organizer" do
-        [
-          'First name',
-          'Last name',
-          'Password',
-          'Email',
-          'Phone number',
-          'Zipcode (personal)',
-        ].each do |label|
-          page.find("input[placeholder='#{label}']").wont_be_nil
-        end
+      it "has button for creating with email signup" do
+        page.must_have_button "Create with Email"
       end
 
-      it "has correct required organizer fields" do
-        ['Email', 'Password', 'First Name', 'Last Name'].each do |label|
-          "input[placeholder='#{label}'][required='required']"
-        end
-      end
-    end
-
-    describe "submitting form" do
-
-      describe "with no errors" do
+      describe "creating subgroup via email signup" do
         before do
-          RESOURCES.each { |r| send("#{r}_count") }
-          deliveries_count
-          perform_enqueued_jobs do
-            fill_out_form(
-              'Name' => 'Jawbreaker',
-              'Description (may contain HTML)' => 'I want to be a boat, I want to learn to swim',
-              'Zipcode (group)' => '90210',
-              'First name' => 'herbert',
-              'Last name' => 'stencil',
-              'Password' => 'password',
-              'Phone number' => '212-867-5309',
-              'Email' => 'foo@bar.com',
-              'Zipcode (personal)' => '90211'
-            )
-            click_button "Submit"
-          end
+          fill_out_form group_values_by_input
+          click_button "Create with Email"
         end
 
-        RESOURCES.each do |resource|
-          it "creates new #{resource}(s)" do
-            if resource === "address"
-              Address.count.must_equal(address_count + 2)
-            else
-              resource.camelize.constantize.count.must_equal(
-                send("#{resource}_count") + 1
-              )
+        it "redirects to signup form" do
+          current_path.must_equal "/groups/#{group.id}/subgroups/signup"
+        end
+
+        describe "viewing signup form" do
+          it "has inputs for creating an organizer" do
+            ['Email*',
+             'Password*',
+             'First Name*',
+             'Last Name*',
+             'Zip Code*',
+             'Phone'].each do |label|
+              page.find("input[placeholder='#{label}']").wont_be_nil
+            end
+          end
+
+          it "has correct required fields" do
+            ['Email*',
+             'Password*',
+             'First Name*',
+             'Last Name*',
+             'Zip Code*'].each do |label|
+              "input[placeholder='#{label}'][required='required']"
             end
           end
         end
 
-        it "redirects to the group's dashboard" do
-          page.current_path.must_equal "/groups/#{Group.last.id}/dashboard"
-        end
-
-        it "saves group info" do
-          Group.last.attributes.slice(*%w[name description]).must_equal(
-            'name' =>  "Jawbreaker",
-            'description' => 'I want to be a boat, I want to learn to swim'
-          )
-        end
-
-        it "saves group location"  do
-          Group.last.location.postal_code.must_equal "90210"
-        end
-
-        it "saves organizer info" do
-          Person.last.attributes.slice(*%w[given_name family_name]).must_equal(
-            'given_name' => 'herbert',
-            'family_name' => 'stencil'
-          )
-        end
-
-        it "saves organizer password" do
-          last_person.encrypted_password.wont_be_nil
-          last_person.valid_password?("password")
-        end
-
-        it "saves organizer contact info" do
-          last_person.email_addresses.last.address.must_equal 'foo@bar.com'
-          last_person.phone_numbers.last.number.must_equal '212-867-5309'
-          last_person.personal_addresses.last.postal_code.must_equal '90211'
-        end
-
-        it "saves contact infos as 'primary'" do
-          last_person.primary_email_address.must_equal 'foo@bar.com'
-          last_person.primary_phone_number.must_equal '212-867-5309'
-          last_person.primary_personal_address.postal_code.must_equal '90211'
-        end
-
-        it "sends a welcome email (asynchronously)" do
-          ActionMailer::Base
-            .deliveries.size.must_equal(deliveries_count + 1)
-        end
-      end
-
-      describe "with errors" do
-        before do
-          RESOURCES.each { |r| send("#{r}_count") }
-          fill_out_form({})
-          click_button "Submit"
-        end
-
-        it "does not create any resources" do
-          RESOURCES.each do |resource|
-            resource.camelize.constantize.count.must_equal(send("#{resource}_count"))
+        describe "clicking 'Cancel'" do
+          before { click_link 'Cancel' }
+          it "returns to subgroup creation page" do
+            current_path.must_equal "/groups/#{group.id}/subgroups/new"
           end
         end
 
-        it "displays errors" do
-          page.must_have_content "error"
-        end
-      end
-
-      describe "with google group integration enabled" do
-        let(:fancy_group){ groups(:ohio_chapter) }
-        let(:google_group_email){ 'ohio-chapter@nationalnetwork.com' }
-        let(:google_group_group_key){ "#{google_group_email}.test-google-a.com" }
-        let(:google_group_url){ "https://groups.google.com/a/nationalnetwork.com/forum/#!forum/ohio-chapter" }
-        let(:authentication_double){ double(Google::Auth::ServiceAccountCredentials) }
-        let(:directory_service_double){ double(Google::Apis::AdminDirectoryV1::DirectoryService)}
-        let(:google_group_double) do
-          double(Google::Apis::AdminDirectoryV1::Group,
-                 id: "0279ka6516ngz0s",
-                 email: google_group_email
+        describe "submitting signup form" do
+          describe "with no errors" do
+            before do
+              RESOURCES.each { |r| send("#{r}_count") }
+              deliveries_count
+              perform_enqueued_jobs do
+                fill_out_form(
+                  'Email*' => 'foo@bar.com',
+                  'Password*' => 'password',
+                  'First Name*' => 'herbert',
+                  'Last Name*' => 'stencil',
+                  'Zip Code*' => '90211',
+                  'Phone' => '212-867-5309'
                 )
-        end
-        let(:group_settings_double){ double(Google::Apis::GroupssettingsV1::Groups) }
-        let(:settings_service_double){ double(Google::Apis::GroupssettingsV1::GroupssettingsService) }
-        let(:google_group_member_double){ double(Google::Apis::AdminDirectoryV1::Member)}
-        let(:google_group_count){ GoogleGroup.count }
+                click_button "Submit"
+              end
+            end
 
-        before do
-          # authentication
-          allow(Google::Auth::ServiceAccountCredentials)
-            .to receive(:make_creds).and_return(authentication_double)
-          allow(authentication_double)
-            .to receive(:sub=)
-          allow(Google::Auth::ServiceAccountCredentials)
-            .to receive(:sub=)
+            RESOURCES.each do |resource|
+              it "creates new #{resource}(s)" do
+                if resource === "address"
+                  Address.count.must_equal(address_count + 2)
+                else
+                  resource.camelize.constantize.count.must_equal(
+                    send("#{resource}_count") + 1
+                  )
+                end
+              end
+            end
 
-          # connecting to directory service
-          allow(Google::Apis::AdminDirectoryV1::DirectoryService)
-            .to receive(:new).and_return(directory_service_double)
-          allow(directory_service_double)
-            .to receive(:authorization=)
+            it "redirects to the group's dashboard" do
+              page.current_path.must_equal "/groups/#{Group.last.id}/dashboard"
+            end
 
-          # creating group
-          allow(Google::Apis::AdminDirectoryV1::Group)
-            .to receive(:new).and_return(google_group_double)
-          allow(directory_service_double)
-            .to receive(:insert_group).and_return(google_group_double)
+            it "saves group info" do
+              Group.last.attributes.slice(*%w[name description]).must_equal(
+                'name' =>  "Jawbreaker",
+                'description' => 'I want to be a boat'
+              )
+            end
 
-          # setting group group permissions
-          allow(Google::Apis::GroupssettingsV1::Groups)
-            .to receive(:new).and_return(group_settings_double)
-          allow(group_settings_double).to receive(:authorization=)
-          allow(Google::Apis::GroupssettingsV1::GroupssettingsService)
-            .to receive(:new).and_return(settings_service_double)
-          allow(settings_service_double).to receive(:authorization=)
-          allow(settings_service_double).to receive(:update_group) # <- expect!
+            it "saves group location"  do
+              Group.last.location.postal_code.must_equal "90210"
+            end
 
-          # adding member
-          allow(Google::Apis::AdminDirectoryV1::Member)
-            .to receive(:new).and_return(google_group_member_double)
-          allow(directory_service_double).to receive(:insert_member)
+            it "saves organizer info" do
+              Person.last.attributes.slice(*%w[given_name family_name]).must_equal(
+                'given_name' => 'herbert',
+                'family_name' => 'stencil'
+              )
+            end
 
-          # count google groups
-          google_group_count
+            it "saves organizer password" do
+              last_person.encrypted_password.wont_be_nil
+              last_person.valid_password?("password")
+            end
 
-          # fill out form!
-          visit "/groups/#{fancy_group.id}/subgroups/new"
-          perform_enqueued_jobs do
-            fill_out_form(
-              'Name' => 'Jawbreaker',
-              'Description (may contain HTML)' => 'I want to be a boat, I want to learn to swim',
-              'Zipcode (group)' => '90210',
-              'First name' => 'herbert',
-              'Last name' => 'stencil',
-              'Password' => 'password',
-              'Phone number' => '212-867-5309',
-              'Email' => 'foo@bar.com',
-              'Zipcode (personal)' => '90211'
-            )
-            click_button "Submit"
+            it "saves organizer contact info" do
+              last_person.email_addresses.last.address.must_equal 'foo@bar.com'
+              last_person.phone_numbers.last.number.must_equal '212-867-5309'
+              last_person.personal_addresses.last.postal_code.must_equal '90211'
+            end
+
+            it "saves contact infos as 'primary'" do
+              last_person.primary_email_address.must_equal 'foo@bar.com'
+              last_person.primary_phone_number.must_equal '212-867-5309'
+              last_person.primary_personal_address.postal_code.must_equal '90211'
+            end
+
+            it "sends a welcome email (asynchronously)" do
+              ActionMailer::Base
+                .deliveries.size.must_equal(deliveries_count + 1)
+            end
+          end # with no errors
+
+          describe "omitting optional fields" do
+            before do
+              group_count; person_count;
+              fill_out_form(
+                'Email*'    => 'foo@bar.com',
+                'Zip Code*' => '11111'
+              )
+              click_button "Submit"
+            end
+
+            it "creates a new group" do
+              Group.count.must_equal group_count + 1
+            end
+
+            it "creates a new person" do
+              Person.count.must_equal person_count + 1
+            end
           end
-        end
 
-        it "creates a google group" do
-          expect(Google::Apis::AdminDirectoryV1::Group)
-            .to have_received(:new).with(email: Group.last.build_google_group_email,
-                                         name: Group.last.name,
-                                         description: GoogleAPI::CreateGoogleGroup::DESCRIPTION)
+          describe "with invalid inputs" do
+            before do
+              RESOURCES.each { |r| send("#{r}_count") }
+              fill_out_form(
+                'Email*'    => 'invalid',
+                'Phone'     => 'invalid',
+                'Zip Code*' => 'invalid'
+              )
+              click_button "Submit"
+            end
 
-          expect(directory_service_double)
-            .to have_received(:insert_group).with(google_group_double)
-        end
+            it "re-renders signup page" do
+              page.must_have_content "Organizer Signup"
+            end
 
-        it "adds permissive settings to google group" do
-          expect(settings_service_double)
-            .to have_received(:update_group).with(google_group_email,
-                                                  group_settings_double)
-        end
+            it "does not create any resources" do
+              RESOURCES.each do |resource|
+                resource.camelize.constantize.count.must_equal(send("#{resource}_count"))
+              end
+            end
 
-        it "adds member to google group" do
-          expect(Google::Apis::AdminDirectoryV1::Member)
-            .to have_received(:new).with(email: Person.last.email,
-                                         role: GoogleAPI::Roles::OWNER)
+            it "shows an error for invalid email address" do
+              page.must_have_content(
+                "Email address 'invalid' is not a valid email address"
+              )
+            end
 
-          expect(directory_service_double)
-            .to have_received(:insert_member).with(google_group_double.id,
-                                                   google_group_member_double)
-        end
+            it "shows an error for invalid phone number" do
+              page.must_have_content(
+                "Phone number 'invalid' is not a valid phone number"
+              )
+            end
 
-        it "stores a record of the new google group" do
-          GoogleGroup.count.must_equal(google_group_count + 1)
-        end
+            it "shows an error for invalid postal code" do
+              page.must_have_content(
+                "Zip code 'invalid' is not a valid zip code"
+              )
+            end
+          end # with invalid inputs
 
-        it "saves the google group's important attributes" do
-          GoogleGroup.last.attributes.slice(*%w[group_id group_key email url])
-            .must_equal(
-              'group_id'  => Group.last.id,
-              'group_key' => google_group_double.id,
-              'email'     => google_group_email,
-              'url'       => google_group_url
-            )
-        end
-      end # with google group integration enabled
-    end # submitting form
+          describe "with google group integration enabled" do
+            let(:fancy_group){ groups(:ohio_chapter) }
+            let(:google_group_email){ 'ohio-chapter@nationalnetwork.com' }
+            let(:google_group_group_key){ "#{google_group_email}.test-google-a.com" }
+            let(:google_group_url){ "https://groups.google.com/a/nationalnetwork.com/forum/#!forum/ohio-chapter" }
+            let(:authentication_double){ double(Google::Auth::ServiceAccountCredentials) }
+            let(:directory_service_double){ double(Google::Apis::AdminDirectoryV1::DirectoryService)}
+            let(:google_group_double) do
+              double(Google::Apis::AdminDirectoryV1::Group,
+                     id: "0279ka6516ngz0s",
+                     email: google_group_email
+                    )
+            end
+            let(:group_settings_double){ double(Google::Apis::GroupssettingsV1::Groups) }
+            let(:settings_service_double){ double(Google::Apis::GroupssettingsV1::GroupssettingsService) }
+            let(:google_group_member_double){ double(Google::Apis::AdminDirectoryV1::Member)}
+            let(:google_group_count){ GoogleGroup.count }
+
+            before do
+              # authentication
+              allow(Google::Auth::ServiceAccountCredentials)
+                .to receive(:make_creds).and_return(authentication_double)
+              allow(authentication_double)
+                .to receive(:sub=)
+              allow(Google::Auth::ServiceAccountCredentials)
+                .to receive(:sub=)
+
+              # connecting to directory service
+              allow(Google::Apis::AdminDirectoryV1::DirectoryService)
+                .to receive(:new).and_return(directory_service_double)
+              allow(directory_service_double)
+                .to receive(:authorization=)
+
+              # creating group
+              allow(Google::Apis::AdminDirectoryV1::Group)
+                .to receive(:new).and_return(google_group_double)
+              allow(directory_service_double)
+                .to receive(:insert_group).and_return(google_group_double)
+
+              # setting group group permissions
+              allow(Google::Apis::GroupssettingsV1::Groups)
+                .to receive(:new).and_return(group_settings_double)
+              allow(group_settings_double).to receive(:authorization=)
+              allow(Google::Apis::GroupssettingsV1::GroupssettingsService)
+                .to receive(:new).and_return(settings_service_double)
+              allow(settings_service_double).to receive(:authorization=)
+              allow(settings_service_double).to receive(:update_group) # <- expect!
+
+              # adding member
+              allow(Google::Apis::AdminDirectoryV1::Member)
+                .to receive(:new).and_return(google_group_member_double)
+              allow(directory_service_double).to receive(:insert_member)
+
+              # count google groups
+              google_group_count
+
+              # finally interact with page!
+              visit "/groups/#{fancy_group.id}/subgroups/new"
+              perform_enqueued_jobs do
+                # fill out group form
+                fill_out_form(
+                  'Name*'       => 'Jawbreaker',
+                  'Description' => 'I want to be a boat',
+                  'Zip Code'    => '90210',
+                )
+                click_button "Create with Email"
+                # fill out organizer signup form
+                fill_out_form(
+                  'Email*' => 'foo@bar.com',
+                  'Password*' => 'password',
+                  'First Name*' => 'herbert',
+                  'Last Name*' => 'stencil',
+                  'Zip Code*' => '90211',
+                  'Phone' => '212-867-5309',
+                )
+                click_button "Submit"
+              end
+            end
+
+            it "creates a google group" do
+              expect(Google::Apis::AdminDirectoryV1::Group)
+                .to have_received(:new).with(email: Group.last.build_google_group_email,
+                                             name: Group.last.name,
+                                             description: GoogleAPI::CreateGoogleGroup::DESCRIPTION)
+
+              expect(directory_service_double)
+                .to have_received(:insert_group).with(google_group_double)
+            end
+
+            it "adds permissive settings to google group" do
+              expect(settings_service_double)
+                .to have_received(:update_group).with(google_group_email,
+                                                      group_settings_double)
+            end
+
+            it "adds member to google group" do
+              expect(Google::Apis::AdminDirectoryV1::Member)
+                .to have_received(:new).with(email: Person.last.email,
+                                             role: GoogleAPI::Roles::OWNER)
+
+              expect(directory_service_double)
+                .to have_received(:insert_member).with(google_group_double.id,
+                                                       google_group_member_double)
+            end
+
+            it "stores a record of the new google group" do
+              GoogleGroup.count.must_equal(google_group_count + 1)
+            end
+
+            it "saves the google group's important attributes" do
+              GoogleGroup.last.attributes.slice(*%w[group_id group_key email url])
+                .must_equal(
+                  'group_id'  => Group.last.id,
+                  'group_key' => google_group_double.id,
+                  'email'     => google_group_email,
+                  'url'       => google_group_url
+                )
+            end
+          end # with google group integration enabled
+        end # submitting form
+      end # picking email path
+    end # viewing group creatoin form
   end # for logged-out person
 
   describe "for logged-in person" do
@@ -293,9 +367,9 @@ class CreateGroupTest < FeatureTest
           deliveries_count
           perform_enqueued_jobs do
             fill_out_form(
-              'Name' => 'Jawbreaker',
-              'Description (may contain HTML)' => 'I want to be a boat',
-              'Zipcode (group)' => '90210'
+              'Name*' => 'Jawbreaker',
+              'Description' => 'I want to be a boat',
+              'Zip Code' => '90210'
             )
             click_button "Submit"
           end

--- a/test/models/concerns/can_signup_test.rb
+++ b/test/models/concerns/can_signup_test.rb
@@ -23,10 +23,10 @@ class CanSignupTest < ActiveSupport::TestCase
 
   describe "instance methods" do
     it "provides a list of associated resources required by a form" do
-      person.signup_resources_for(form)
-        .must_equal([person.email_addresses,
-                     person.personal_addresses,
-                     person.phone_numbers])
+      person.build_signup_resources
+      [person.email_addresses,
+       person.personal_addresses,
+       person.phone_numbers].each { |x| x.wont_be_empty }
     end
   end
 

--- a/test/routes/signup_routes_test.rb
+++ b/test/routes/signup_routes_test.rb
@@ -1,0 +1,24 @@
+require_relative "../test_helper"
+
+class SubgroupRoutesTest < ActionDispatch::IntegrationTest
+  it "has a subgroups#new route" do
+    assert_routing(
+      { path: "/groups/1/subgroups/new", method: :get },
+      { controller: "subgroups", action: "new", group_id: "1" }
+    )
+  end
+
+  it "has a subgroups#create route" do
+    assert_routing(
+      { path: "/groups/1/subgroups", method: :post },
+      { controller: "subgroups", action: "create", group_id: "1" }
+    )
+  end
+
+  it "has a subgroups#signup route" do
+    assert_routing(
+      { path: "/groups/1/subgroups/signup", method: :post },
+      { controller: "subgroups", action: "signup", group_id: "1" }
+    )
+  end
+end


### PR DESCRIPTION
resolves #665 
_________________________

# Functionality
* on step 1, gather info about group
* offer choice of submit buttons (currently only "create with email" exists)
* validate group field submissions, if valid..
* proceed to step 2, where we...
* gather info about organizer, if valid...
* create group, organizer, membership, google group
* sign in and redirect organizer to group dashboard page

# Implementation Notes
side-effects:
* extract `signup` layout, share it between signup flows (join- & create-group)
* extract `signup_fields_email` partial, share between signup flows
* re-introduce (and re-write) `Person.build_for_signup`
* standardize formatting of "Zip Code", "Create with Email"`

# Screenshots

*Step 1:*
![create-group-step-1](https://user-images.githubusercontent.com/6032844/39902665-56a88374-549d-11e8-9e0f-b0af19034c1d.png)

*Step 2:*
![create-group-step-2](https://user-images.githubusercontent.com/6032844/39902672-600c7542-549d-11e8-87b4-68fbb2518695.png)

*End Result:*
![create-group-step-3](https://user-images.githubusercontent.com/6032844/39902683-69b037d2-549d-11e8-8c46-a82cb10f582a.png)
