### PR TITLE
Fix Account Redirect

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -141,6 +141,7 @@ group :test do
   gem 'rails-controller-testing'
   gem 'webmock'
   #gem 'minitest-spec'
+  gem 'minitest', '~> 5.10.3'
   gem 'minitest-spec-rails'
   gem 'minitest-matchers'
   gem 'minitest-focus'
@@ -148,6 +149,7 @@ group :test do
   gem 'minitest-rails-capybara'
   gem 'rspec-mocks'
   gem 'selenium-webdriver'
+  gem 'launchy'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,8 @@ GEM
       addressable
       faraday
       json (>= 1.8)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     libv8 (5.3.332.38.5)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -269,7 +271,7 @@ GEM
     mini_portile2 (2.3.0)
     mini_racer (0.1.9)
       libv8 (~> 5.3)
-    minitest (5.11.3)
+    minitest (5.10.3)
     minitest-capybara (0.8.2)
       capybara (~> 2.2)
       minitest (~> 5.0)
@@ -538,8 +540,10 @@ DEPENDENCIES
   jquery-ui-rails (~> 5.0.4)
   kaminari
   koala
+  launchy
   memory_profiler
   mini_racer
+  minitest (~> 5.10.3)
   minitest-focus
   minitest-matchers
   minitest-rails-capybara

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -59,7 +59,6 @@ class ApplicationController < ActionController::Base
     authorize! :manage, current_group
   end
 
-
   def has_group_read_access?
     if authorize! :read, current_group
       return true if has_role?(:volunteer)

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -137,6 +137,8 @@ class MembersController < ApplicationController
   end
 
   def authorize_member_access
+    return if is_signup_form?
+    
     case action_name 
     when "edit", "update"
       authorize! :manage, @member

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -3,13 +3,16 @@ class MembersController < ApplicationController
   # authentication
   before_action :authenticate_person!, except: %i[new create]
   before_action :allow_logged_out_signups, only: %i[new create]
-  before_action :authorize_group_access
+  before_action :authorize_group_access, except: %i[edit account update]
+
   # setters
   before_action :set_signup_mode, only: %i[new create edit update]
   before_action :set_oauth, only: %i[new create edit update]
   before_action :set_group
   before_action :set_members, only: :index
   before_action :set_member, only: [:show, :edit, :update, :destroy, :attendances]
+  before_action :set_person, only: [:account]
+  before_action :authorize_member_access, only: %i[edit account update]
   before_action :build_member, only: %i[new create]
   before_action :build_member_resources, only: %i[new edit]
   before_action :set_target, only: %i[new create edit update]
@@ -38,15 +41,9 @@ class MembersController < ApplicationController
     end
   end
 
-
-
   # GET /groups/:id/members/new
   def new
-    if is_signup_form?
-      render "signup_form_#{@signup_mode}", layout: "signup"
-    else
-      authorize! :manage, @group # dupe of authorize_group_access? (@aguestuser)
-    end
+    return render "signup_form_#{@signup_mode}", layout: "signup" if is_signup_form?
   end
 
   # POST /groups/:id/members/
@@ -68,16 +65,11 @@ class MembersController < ApplicationController
 
   # GET /groups/:id/members/1/edit
   def edit
-    if is_signup_form?
-      render "signup_form_#{@signup_mode}", layout: "signup"
-    else
-      @groups = Group.all
-      authorize! :manage, @group # redundant? (@aguestuser)
-    end
+    return render "signup_form_#{@signup_mode}", layout: "signup" if is_signup_form?
   end
 
-  # PATCH/PUT /groups/1
-  # PATCH/PUT /groups/1.json
+  # PATCH/PUT /groups/:id/members/1
+  # PATCH/PUT /groups/:id/members/1.json
   def update
     respond_to do |format|
       if is_oauth_signup?
@@ -110,11 +102,9 @@ class MembersController < ApplicationController
   end
 
   def account
-    group = Group.find(params[:group_id]) if params[:group_id]
-    person = Person.find(params[:person_id]) if params[:person_id]
+    group = determine_group_for_account
 
-    valid_group = (group && group.members.include?(person)) ? group : person.groups.first
-    return redirect_to edit_group_member_path(group_id: valid_group.id, id: person.id)
+    return redirect_to edit_group_member_path(group_id: group.id, id: @person.id)
   end
 
   private
@@ -146,6 +136,14 @@ class MembersController < ApplicationController
       .tap { |person_attrs| maybe_set_memberships(person_attrs) }
   end
 
+  def authorize_member_access
+    case action_name 
+    when "edit", "update"
+      authorize! :manage, @member
+    else
+      authorize! :manage, @person
+    end
+  end
 
   def handle_empty_contact_info(person_attrs)
     if person_attrs.dig('phone_numbers_attributes', '0', 'number') == ''
@@ -229,6 +227,10 @@ class MembersController < ApplicationController
     end
   end
 
+  def set_person
+    @person = Person.find(params.require(:person_id).to_i)
+  end
+
   def set_members
     member_ids = Membership.where(:group_id =>@group.affiliates.pluck(:id).push(@group.id) ).pluck(:person_id)
 
@@ -269,7 +271,6 @@ class MembersController < ApplicationController
     end
   end
 
-
   def build_member_resources
     %i[personal_addresses email_addresses phone_numbers].each do |x|
       @member.send(x).build(primary: true) if @member.send(x).empty?
@@ -286,6 +287,11 @@ class MembersController < ApplicationController
 
   def is_email_signup?
     @signup_mode == 'email'
+  end
+
+  def determine_group_for_account
+    group = Group.find_by_id(params[:group_id])
+    group&.member?(@person) ? group : @person.groups.first
   end
 
   ##########################

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -11,6 +11,19 @@ class Ability
         person.groups.include?(current_group)
       end
 
+      can :manage, Person do |person|
+        permitted_flag = false
+        permitted_flag = true if person == current_user
+        permitted_flag = true if Membership.organizer.exists?(group: current_group, person: current_user)
+
+        current_group.affiliated_with.each do |affilated_group|
+          if permitted_flag == false && Membership.organizer.exists?(person: current_user, group: affilated_group)
+            permitted_flag = true
+          end
+        end
+        permitted_flag
+      end
+
       can :read, Attendance do |attendance|
         attendance.person.groups.include?(current_group)
       end
@@ -38,6 +51,7 @@ class Ability
             permitted_flag = true
           end
         end
+
         permitted_flag
       end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -21,6 +21,8 @@ class Ability
             permitted_flag = true
           end
         end
+
+        permitted_flag = false unless Membership.where(person: person, group: current_group).exists?
         permitted_flag
       end
 

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -134,7 +134,7 @@ class Group < ApplicationRecord
   end
 
   def member?(person)
-    member_members.include?(person)
+    memberships.where(person_id: person.id).any?
   end
 
   def volunteer?(person)

--- a/test/controllers/members_controller_test.rb
+++ b/test/controllers/members_controller_test.rb
@@ -148,4 +148,15 @@ class MembersControllerTest < ActionDispatch::IntegrationTest
     get attendances_group_member_url(group_id: person.groups.first.id, id: person.id), as: :json
     assert_response :success
   end
+
+  describe "#edit" do
+    it "allows a member to access" do
+      group = groups(:fourth)
+      person = people(:one)
+      sign_in person 
+
+      get edit_group_member_url(group_id: group.id, id: person.id, signup_mode: "email")
+      assert_response 200
+    end
+  end
 end

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -1,170 +1,230 @@
 require 'test_helper'
 
 class AbilityTest < ActiveSupport::TestCase
-  test 'can read ONLY current group\'s events' do
-    current_person = Person.first
-    current_group = Group.first
-    group_event = Event.first
-    ability = Ability.new(current_person, current_group)
+  describe "Event" do
+    test 'can read ONLY current group\'s events' do
+      current_person = Person.first
+      current_group = Group.first
+      group_event = Event.first
+      ability = Ability.new(current_person, current_group)
 
-    assert ability.can? :read, group_event, 'current person is able to read current group\'s events'
-    assert_not ability.can? :read, Event.last, 'current person is not able to read current group\'s events'
+      assert ability.can? :read, group_event, 'current person is able to read current group\'s events'
+      assert_not ability.can? :read, Event.last, 'current person is not able to read current group\'s events'
+    end
   end
 
-  test 'can read ONLY current group\'s people' do
-    current_person = Person.first
-    current_group = Group.first
+  describe "Attendance" do
+    test 'can read ONLY current group\'s attendances' do
+      current_person = Person.first
+      current_group = Group.first
+      group_attendance = Attendance.first
+      ability = Ability.new(current_person, current_group)
 
-    ability = Ability.new(current_person, current_group)
-
-    assert ability.can? :read, current_person, 'current person is able to read current group\'s people'
-    assert_not ability.can? :read, Person.last, 'current person is not able to read current group\'s people'
+      assert ability.can? :read, group_attendance, 'current person is able to read current group\'s attendances'
+      assert ability.cannot? :read, Attendance.last, 'current person is not able to read current group\'s attendances'
+    end
   end
 
-  test 'can read ONLY current group\'s attendances' do
-    current_person = Person.first
-    current_group = Group.first
-    group_attendance = Attendance.first
-    ability = Ability.new(current_person, current_group)
+  describe "Group" do
+    test 'can manage current group' do
+      organizer = Membership.organizer.first.person
+      current_group = Membership.organizer.first.group
+      ability = Ability.new(organizer, current_group)
+      assert ability.can? :manage, Group, 'the user can manage current group if has role organizer'
+    end
 
-    assert ability.can? :read, group_attendance, 'current person is able to read current group\'s attendances'
-    assert ability.cannot? :read, Attendance.last, 'current person is not able to read current group\'s attendances'
+    test 'can not manage current group' do
+      member = Membership.member.first.person
+      current_group = Membership.member.first.group
+      ability = Ability.new(member, current_group)
+      assert_not ability.can? :manage, current_group, 'the user can manage current group if has role member'
+    end
+
+    test 'admin can manage ANY group' do
+      admin = people(:admin)
+      group = groups(:two)
+      current_group = groups(:test)
+      ability = Ability.new(admin, current_group)
+      assert ability.can? :manage, group, 'the user can manage the group'
+    end
+
+    test 'organizer can manage it\'s groups' do
+      organizer = people(:organizer)
+      current_group = groups(:test)
+      ability = Ability.new(organizer, current_group)
+      assert ability.can? :manage, current_group, 'the organizer can manage the group'
+    end
+
+    test 'organizer can manage affiliates groups' do
+      organizer = people(:organizer)
+      current_group = groups(:test)
+      group = groups(:fourth)
+      ability = Ability.new(organizer, current_group)
+      assert ability.can? :manage, group, 'the organizer can manage affiliate group'
+    end
+
+
+    test 'organizer can not manage other groups membership roles' do
+      person = people(:one)
+      current_group = groups(:test)
+      membership = memberships(:member1)
+      ability = Ability.new(person, current_group)
+      assert ability.cannot?(:update, membership)
+    end
+
+  #this should return truthy, permissions error seems to be a reality
+    test 'organizer can manage own groups membership roles' do
+      organizer = people(:organizer)
+      current_group = groups(:test)
+      membership = memberships(:member1)
+      ability = Ability.new(organizer, current_group)
+      assert ability.can?(:manage, current_group)
+      assert ability.can?(:manage, membership)
+    end
+
+  #this should return truthy
+    test 'admin can manage other groups membership roles' do
+      admin = people(:admin)
+      current_group = groups(:two)
+      membership = memberships(:member2)
+      ability = Ability.new(admin, current_group)
+      assert ability.can?(:manage, current_group)
+      assert ability.can?(:manage, membership)
+    end
+
+    test 'organizer can not manage not affiliate group' do
+      organizer = people(:organizer)
+      current_group = groups(:test)
+      group = groups(:two)
+      ability = Ability.new(organizer, current_group)
+      assert_not ability.can? :manage, group, 'the organizer can not manage not affiliate group'
+    end
+
+    test 'members can read current group' do
+      person = people(:one)
+      current_group = person.groups.first
+
+      ability = Ability.new(person, current_group)
+      assert ability.can?(:read, current_group)
+      assert ability.cannot?(:manage, current_group)
+    end
+
+    test 'members cannot read others groups' do
+      person = people(:one)
+      current_group = groups(:two)
+
+      ability = Ability.new(person, current_group)
+      assert ability.cannot?(:read, current_group)
+    end
+
+    test 'members can read affiliates groups' do
+      current_group = groups(:test)
+      group = groups(:fourth)
+      person = people(:member1)
+
+      ability = Ability.new(person, current_group)
+      assert ability.can? :read, group
+      assert ability.cannot?(:manage, current_group)
+    end
+
+    test 'volunteers can read current group' do
+      membership = memberships(:one)
+      membership.update(role: 2)
+
+      person = membership.person
+      current_group = membership.group
+
+      ability = Ability.new(person, current_group)
+      assert ability.can?(:read, current_group)
+      assert ability.cannot?(:manage, current_group)
+    end
+
+    test 'volunteers cannot read others groups' do
+      membership = memberships(:forth)
+      membership.update(role: 2)
+
+      person = membership.person
+      current_group = groups(:two)
+
+      ability = Ability.new(person, current_group)
+      assert ability.cannot?(:read, current_group)
+      assert ability.cannot?(:manage, current_group)
+    end
+
+    test 'volunteers can read affiliates groups' do
+      membership = memberships(:one)
+      membership.update(role: 2)
+      current_group = groups(:test)
+      group = groups(:fourth)
+      person = people(:member1)
+
+      ability = Ability.new(person, current_group)
+      assert ability.can? :read, group
+      assert ability.cannot?(:manage, current_group)
+    end
   end
 
-  test 'can manage current group' do
-    organizer = Membership.organizer.first.person
-    current_group = Membership.organizer.first.group
-    ability = Ability.new(organizer, current_group)
-    assert ability.can? :manage, Group, 'the user can manage current group if has role organizer'
-  end
+  describe "Person" do
+    describe "manage" do
+      it "allows person to manage themself" do
+        current_person = people(:one)
+        current_group = groups(:one)
 
-  test 'can not manage current group' do
-    member = Membership.member.first.person
-    current_group = Membership.member.first.group
-    ability = Ability.new(member, current_group)
-    assert_not ability.can? :manage, current_group, 'the user can manage current group if has role member'
-  end
+        ability = Ability.new(current_person, current_group)
 
-  test 'admin can manage ANY group' do
-    admin = people(:admin)
-    group = groups(:two)
-    current_group = groups(:test)
-    ability = Ability.new(admin, current_group)
-    assert ability.can? :manage, group, 'the user can manage the group'
-  end
+        assert ability.can? :manage, current_person
+      end
 
-  test 'organizer can manage it\'s groups' do
-    organizer = people(:organizer)
-    current_group = groups(:test)
-    ability = Ability.new(organizer, current_group)
-    assert ability.can? :manage, current_group, 'the organizer can manage the group'
-  end
+      it "allows organizer to manage others in the group" do
+        current_person = people(:organizer)
+        current_group = groups(:test)
+        person_in_group = people(:member1)
 
-  test 'organizer can manage affiliates groups' do
-    organizer = people(:organizer)
-    current_group = groups(:test)
-    group = groups(:fourth)
-    ability = Ability.new(organizer, current_group)
-    assert ability.can? :manage, group, 'the organizer can manage affiliate group'
-  end
+        ability = Ability.new(current_person, current_group)
 
+        assert ability.can? :manage, person_in_group
+      end
 
-  test 'organizer can not manage other groups membership roles' do
-    person = people(:one)
-    current_group = groups(:test)
-    membership = memberships(:member1)
-    ability = Ability.new(person, current_group)
-    assert ability.cannot?(:update, membership)
-  end
+      it "allows organizer to manage others in affiliated groups" do
+        current_person = people(:organizer)
+        current_group = groups(:fourth)
+        person_in_group = people(:one)
 
-#this should return truthy, permissions error seems to be a reality
-  test 'organizer can manage own groups membership roles' do
-    organizer = people(:organizer)
-    current_group = groups(:test)
-    membership = memberships(:member1)
-    ability = Ability.new(organizer, current_group)
-    assert ability.can?(:manage, current_group)
-    assert ability.can?(:manage, membership)
-  end
+        ability = Ability.new(current_person, current_group)
 
-#this should return truthy
-  test 'admin can manage other groups membership roles' do
-    admin = people(:admin)
-    current_group = groups(:two)
-    membership = memberships(:member2)
-    ability = Ability.new(admin, current_group)
-    assert ability.can?(:manage, current_group)
-    assert ability.can?(:manage, membership)
-  end
+        assert ability.can? :manage, person_in_group
+      end
 
-  test 'organizer can not manage not affiliate group' do
-    organizer = people(:organizer)
-    current_group = groups(:test)
-    group = groups(:two)
-    ability = Ability.new(organizer, current_group)
-    assert_not ability.can? :manage, group, 'the organizer can not manage not affiliate group'
-  end
+      it "does not allow organizer to manage others in non-affiliated groups" do
+        current_person = people(:organizer)
+        current_group = groups(:two)
+        person_in_group = people(:member2)
 
-  test 'members can read current group' do
-    person = people(:one)
-    current_group = person.groups.first
+        ability = Ability.new(current_person, current_group)
 
-    ability = Ability.new(person, current_group)
-    assert ability.can?(:read, current_group)
-    assert ability.cannot?(:manage, current_group)
-  end
+        assert ability.cannot? :manage, person_in_group
+      end
 
-  test 'members cannot read others groups' do
-    person = people(:one)
-    current_group = groups(:two)
+      it "does not allow person not in current group to manage" do
+        current_person = people(:one)
+        current_group = groups(:two)
 
-    ability = Ability.new(person, current_group)
-    assert ability.cannot?(:read, current_group)
-  end
+        ability = Ability.new(current_person, current_group)
 
-  test 'members can read affiliates groups' do
-    current_group = groups(:test)
-    group = groups(:fourth)
-    person = people(:member1)
+        assert ability.cannot? :manage, current_person
+      end
+    end
 
-    ability = Ability.new(person, current_group)
-    assert ability.can? :read, group
-    assert ability.cannot?(:manage, current_group)
-  end
+    describe "read" do
+      test 'can read ONLY current group\'s people' do
+        current_person = Person.first
+        current_group = Group.first
 
-  test 'volunteers can read current group' do
-    membership = memberships(:one)
-    membership.update(role: 2)
+        ability = Ability.new(current_person, current_group)
 
-    person = membership.person
-    current_group = membership.group
-
-    ability = Ability.new(person, current_group)
-    assert ability.can?(:read, current_group)
-    assert ability.cannot?(:manage, current_group)
-  end
-
-  test 'volunteers cannot read others groups' do
-    membership = memberships(:forth)
-    membership.update(role: 2)
-
-    person = membership.person
-    current_group = groups(:two)
-
-    ability = Ability.new(person, current_group)
-    assert ability.cannot?(:read, current_group)
-    assert ability.cannot?(:manage, current_group)
-  end
-
-  test 'volunteers can read affiliates groups' do
-    membership = memberships(:one)
-    membership.update(role: 2)
-    current_group = groups(:test)
-    group = groups(:fourth)
-    person = people(:member1)
-
-    ability = Ability.new(person, current_group)
-    assert ability.can? :read, group
-    assert ability.cannot?(:manage, current_group)
+        assert ability.can? :read, current_person, 'current person is able to read current group\'s people'
+        assert_not ability.can? :read, Person.last, 'current person is not able to read current group\'s people'
+      end
+    end
   end
 end

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -179,16 +179,11 @@ class GroupTest < ActiveSupport::TestCase
 
     group_member = Person.create(given_name: 'given_name', family_name: 'family_name')
     no_group_member = Person.create(given_name: 'no_member', family_name: 'no_member')
-    organizer = Person.create(given_name: 'organizer', family_name: 'organizer')
 
-    group_membership = Membership.create(person: organizer, role: 'organizer')
-    group.members.push(group_member)
-    group.memberships.push(group_membership)
+    group_membership = Membership.create(person: group_member, group: group, role: 'organizer')
 
     assert group.member?(group_member)
     assert_not group.member?(no_group_member)
-    assert_not group.member?(organizer)
-
   end
 
   test '#affiliation_with_role?' do


### PR DESCRIPTION
Closes #663 
_______________________

* **BUG:** if I am a member of a group (not an organizer) clicking "account" in the nav dropdown redirects to /home instead my account edit page
* **CAUSE:** group-based permissions only allow organizers to edit a group member
* **FIX:** introduced person-based permissions and allow a person to edit themselves