### PR TITLE
resolve #677 -- "import members to group from CSV" 

### DIFF
--- a/app/models/concerns/bulk_import.rb
+++ b/app/models/concerns/bulk_import.rb
@@ -1,0 +1,67 @@
+module BulkImport
+  extend ActiveSupport::Concern
+  VALID_HEADERS = ['first_name', 'last_name', 'email', 'zip_code', 'phone'].freeze
+  REQUIRED_INDICES = (0..3)
+  INVALID_HEADER_MSG = "Invalid CSV headers. Required: #{VALID_HEADERS}"
+  MALFORMED_ROWS_MSG = "Failed to import the following malformed rows:\n"
+
+  included do
+    # String -> String|Error
+    def bulk_import_members(csv_str)
+      # USAGE FROM CONSOLE:
+      # > group = Group.find(1)
+      # > csv = <paste_csv_here>
+      # > group.bulk_import_members(csv)
+      headers, *rows = CSV.parse(csv_str)
+      raise INVALID_HEADER_MSG unless headers == VALID_HEADERS
+      invalid_rows = try_import_members(rows)
+      raise "#{MALFORMED_ROWS_MSG} #{invalid_rows}" unless invalid_rows.empty?
+      "ok"
+    end
+
+    private
+
+    # Array<String> -> Array<String>
+    def try_import_members(rows)
+      # import valid rows, return array of invalid rows
+      rows
+        .map{ |row| try_import_member(row) }
+        .compact
+        .map{ |row| row.join(", ") }
+        .join("\n")
+    end
+
+    # String -> String?
+    def try_import_member(row)
+      return unless well_formed?(row)
+      person = Person.create(parse_attributes(row))
+      person.valid? ? nil : row
+    end
+
+    # String -> Boolean
+    def well_formed?(row)
+      #binding.remote_pry
+      REQUIRED_INDICES.map{ |i| row[i].present? }.all?
+    end
+
+    # Array<String> -> Hash<PersonAttributes>
+    def parse_attributes(row)
+      {
+        given_name:  row[0],
+        family_name: row[1],
+        memberships_attributes: [
+          { group: self, role: 'member' }
+        ],
+        email_addresses_attributes: [
+          { primary: true, address: row[2] }
+        ],
+        personal_addresses_attributes: [
+          { primary: true, postal_code: row[3] }
+        ],
+        phone_numbers_attributes: row[4] ? [
+          { primary: true, number:  row[4]}
+        ] : []
+      }
+    end
+  end
+end

--- a/app/models/concerns/bulk_import.rb
+++ b/app/models/concerns/bulk_import.rb
@@ -31,11 +31,16 @@ module BulkImport
         .join("\n")
     end
 
-    # String -> String?
+    # String -> Nil|String
     def try_import_member(row)
       return unless well_formed?(row)
       person = Person.create(parse_attributes(row))
-      person.valid? ? nil : row
+      if person.valid?
+        Members::AfterCreate.call(member: person, group: self)
+        nil
+      else
+        row
+      end
     end
 
     # String -> Boolean

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,6 +2,7 @@ class Group < ApplicationRecord
   include ArelHelpers::ArelTable
   include Networkable
   include UrlHelpers
+  include BulkImport
   #has_paper_trail
   acts_as_taggable
 

--- a/app/services/members/after_create.rb
+++ b/app/services/members/after_create.rb
@@ -3,7 +3,6 @@ class Members::AfterCreate
     def call(member:, group:)
       # TODO (aguestuser|10 Apr 2018): we should probably send a welcome email?
       if FeatureToggle.on?(:google_groups, group)
-        # TODO (aguestuser|10 Apr 2018): perform in a job!!!
         GoogleGroupJobs::
           AddNewMemberToGroupJob.perform_later(member: member, group: group)
       end

--- a/test/models/concerns/bulk_import_test.rb
+++ b/test/models/concerns/bulk_import_test.rb
@@ -1,0 +1,120 @@
+require_relative "../../test_helper"
+
+class BulkImportTest < ActiveSupport::TestCase
+  describe ".bulk_import_members" do
+    let(:group){groups(:fantastic_four) }
+    let(:person_count){ Person.count }
+
+    describe "with correctly formatted csv" do
+      let(:csv) do
+        "first_name,last_name,email,zip_code,phone\n" +
+          "alice,foo,alice@anarchist.website,11111,222-222-2222\n" +
+          "bob,foo,bob@anarchist.website,11111,222-222-2222,\n" +
+          "carla,foo,carla@anarchist.website,11111,222-222-2222,\n"
+      end
+
+      before do
+        person_count
+        group.bulk_import_members(csv)
+      end
+
+      it "creates a person for each row" do
+        Person.count.must_equal person_count + 3
+      end
+
+      it "makes each person a member of group" do
+        Person.last(3).each do |person|
+          person.is_member_of?(group).must_equal true
+        end
+      end
+
+      it "does not create passwords for any person" do
+        Person.last(3).each do |person|
+          person.encrypted_password.must_be_empty
+        end
+      end
+
+      it "stores contact info for each person" do
+        Person.last(3).each do |person|
+          [:primary_phone_number,
+           :primary_email_address,
+           :primary_personal_address
+          ].each do |info|
+            person.send(info).wont_be_nil
+          end
+        end
+      end
+    end
+
+    describe "with omitted optional field" do
+      let(:csv) do
+        "first_name,last_name,email,zip_code,phone\n" +
+          "alice,foo,alice@anarchist.website,11111,\n"
+      end
+
+      it "creates a person" do
+        assert_difference ->{Person.count}, 1 do
+          group.bulk_import_members(csv)
+        end
+      end
+    end
+
+    describe "with incorrectly formatted rows" do
+      let(:csv) do
+        "first_name,last_name,email,zip_code,phone\n" +
+          # valid
+          "alice,foo,alice@anarchist.website,11111,222-222-2222\n" +
+          invalid_rows
+      end
+
+      let(:invalid_rows) do
+        # missing first name
+        ",foo,blah@anarchist.website,11111,222-222-2222\n" +
+          # missing last name
+          "alice,,blah2@anarchist.website,11111,222-222-2222\n" +
+          # invalid email
+          "bob,foo,invalid,11111,222-222-2222,\n" +
+          # missing email
+          "bob,foo,,11111,222-222-2222,\n" +
+          # invalid zip
+          "carla,foo,carla@anarchist.website,invalid,222-222-2222,\n" +
+          # missing zip
+          "carla,foo,carla@anarchist.website,,222-222-2222,\n" +
+          # invalid phone
+          "carla,foo,carla@anarchist.website,11111,invalid,\n"
+      end
+
+      it "imports correctly formatted rows" do
+        assert_difference ->{Person.count}, 1 do
+          begin
+            group.bulk_import_members(csv)
+          rescue
+          end
+        end
+      end
+
+      it "raises an error including incorrectly formatted rows" do
+        ->{ group.bulk_import_members(csv) }
+          .must_raise "#{BulkImport::MALFORMED_ROWS_MSG} #{invalid_rows}"
+      end
+    end
+
+    describe "with incorrectly formatted headers" do
+      let(:csv){ "foo,bar\nbaz,bam" }
+
+      it "raises an error describing formatting errors" do
+        ->{ group.bulk_import_members(csv) }
+          .must_raise BulkImport::INVALID_HEADER_MSG
+      end
+
+      it "imports no people" do
+        assert_no_difference ->{Person.count}, 0 do
+          begin
+            group.bulk_import_members(csv)
+          rescue
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
resolves #677 
___________________________________

# Functionality
* allows an admin to bulk import a CSV list of members into a group from the rails console as follows:

```ruby
> group = Group.find(1)
> csv = <paste csv string here>
> group.bulk_import_members(csv)> 
```

# Implementation Notes

* create `BulkImport` concern and include it on `Group`
* it exposes `.bulk_import_members`, which:
  * takes a csv string
  * imports all valid rows as new group members
  * raises an error for malformed rows (after importing well-formed ones)
  * raises an error if headers are malformed (and imports nothing)

# QA Instructions

## Verify Happy Path

```ruby
> group = Group.first
> group.network_memberships # make sure its a member of NationalNetwork
> csv = "first_name,last_name,email,zip_code,phone\n" +
  "alice,foo,alice@anarchist.website,11111,222-222-2222\n" +
  "bob,foo,bob@anarchist.website,11111,222-222-2222,\n"
> Person.count
> group.bulk_import_members(csv)

# verification
# verify `GoogleGroupJobs::AddNewMemberToGroupJob.perform_later` called twice
> Person.count # should increase by 2
> Person.last(2).map{ |p| p.is_member_of?(group) }
> Person.last(2).map{ |p| p.missing_contact_info? }

# cleanup
> Person.last(2).map(&:destroy)
```

## Verify Omitting Optional Field Works

```ruby
> csv = "first_name,last_name,email,zip_code,phone\n" +
        "alice,foo,alice@anarchist.website,11111,\n"
> Person.count
> group.bulk_import_members(csv)

# verification
> Person.count # should increase by 1
> Person.last.is_member_of?(group)
> Person.last.missing_contact_info?

# cleanup
> Person.last.destroy
```

## Verify Incorrectly Formatted Rows Not Imported

```ruby
> csv = "first_name,last_name,email,zip_code,phone\n" +
        "alice,foo,alice@anarchist.website,11111,222-222-2222\n" +
        ",foo,blah@anarchist.website,11111,222-222-2222\n" +
        "alice,,blah2@anarchist.website,11111,222-222-2222\n" +
        "bob,foo,invalid,11111,222-222-2222,\n" +
        "bob,foo,,11111,222-222-2222,\n" +
        "carla,foo,carla@anarchist.website,invalid,222-222-2222,\n" +
        "carla,foo,carla@anarchist.website,,222-222-2222,\n" +
        "carla,foo,carla@anarchist.website,11111,invalid,\n"

> group.bulk_import_members(csv) # should raise error with last 7 rows

# verification
> Person.count # should increase by 1
```

## Verify Malformed Headers Block All Imports
```ruby
> csv = "foo,bar\nbaz,bam"
> group.bulk_import_members(csv) # should raise error

# verification
> Person.count # should increase by 0
```
