### PR TITLE
resolve #679 - "handle login with wrong email addresses"

### DIFF
--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -62,7 +62,7 @@ body.logged_out {
   #content_wrapper {
     #active_admin_content {
       box-shadow: none;
-      h2 {
+      .logo {
         font-size: 0;
         box-shadow: none;
         color: #0069ff;
@@ -77,9 +77,6 @@ body.logged_out {
         padding: 0.5em 1em;
         background-color: transparent;
         font-weight: normal;
-      }
-      #error_explanation {
-        display: none;
       }
 
       .action input[type="submit"] {
@@ -101,4 +98,43 @@ body.logged_out {
       }
     }
   }
+  h3 {
+      margin-top: 1em;
+  }
+  .password-form-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      #error_explanation {
+          @extend .error_box;
+          h2 {
+              display: none;
+          }
+          li {
+              list-style-type: none;
+              margin: 1rem 0 0 -1rem;
+          }
+      }
+      .field_with_errors {
+          width: 100%;
+      }
+      input#person_email {
+          @extend .form-control;
+          width: 100%;
+      }
+  }
+}
+
+.error_box {
+    border: 1px solid $red;
+    margin-top: 1.5rem;
+    border-radius: .5rem;
+    color: $red;
+    background-color: lightpink;
+}
+
+.flash_error {
+    @extend .error_box;
+    padding: 1rem;
+    margin-top: 2rem!important;
 }

--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -130,3 +130,18 @@ $primaryblue: rgba(2, 117, 216, 1);
     @extend .button;
     @extend .btn-primary;
 }
+
+.btn-password {
+    @extend button;
+}
+
+.modal-actions {
+    display: flex;
+    flex-direction: row;
+    padding-bottom: 1rem;
+    justify-content: center;
+    margin-top: 2rem;
+    .btn {
+        margin: 0 .5rem 0 .5rem;
+    }
+}

--- a/app/assets/stylesheets/member_form.scss
+++ b/app/assets/stylesheets/member_form.scss
@@ -66,17 +66,6 @@ $lightgray: rgba(0, 0, 0, 0.05);
     }
 }
 
-.modal-actions {
-    display: flex;
-    flex-direction: row;
-    padding-bottom: 1rem;
-    justify-content: center;
-    margin-top: 2rem;
-    .btn {
-        margin: 0 .5rem 0 .5rem;
-    }
-}
-
 .add-contact-field {
     margin-top: 0;
 }

--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -1,0 +1,30 @@
+module DeviseHelper
+  def devise_error_messages!
+    return "" unless devise_error_messages?
+
+    sentence = I18n.t("errors.messages.not_saved",
+                      :count => resource.errors.count,
+                      :resource => resource.class.model_name.human.downcase)
+    messages = resource
+                 .errors
+                 .full_messages
+                 .map { |msg| content_tag(:li, msg) }
+                 .join
+                 .gsub("Email not found",
+                       "Oops! No account exists with that email. <br/> Did you sign up with a different email? <br/>Contact info@affinity.works if problem persists.")
+
+    html = <<-HTML
+    <div id="error_explanation">
+      <h2>#{sentence}</h2>
+      <ul>#{messages}</ul>
+    </div>
+    HTML
+
+    html.html_safe
+  end
+
+  def devise_error_messages?
+    !resource.errors.empty?
+  end
+
+end

--- a/app/views/active_admin/devise/passwords/new.html.erb
+++ b/app/views/active_admin/devise/passwords/new.html.erb
@@ -1,20 +1,18 @@
-<div class="login-content pt-5">
-    
-<h2>Forgot your password?</h2>
+<div class="login-content pt-5 password-form-container">
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+  <div class="logo"></div>
+  <h3>Forgot your password?</h3>
 
-  <div class="field form-group row mt-5">
-    <%= f.label :email, class: "col-2 col-form-label mr-4" %><br />
-    <%= f.email_field :email, autofocus: true, class: "form-control col-md-9" %>
-  </div>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <%= devise_error_messages! %>
 
-  <div class="actions text-right">
-    <%= f.submit "Send me reset password instructions", class: 'btn btn-success' %>
-  </div>
-<% end %>
-<div class="text-right mt-4">
-  <%= render "devise/shared/links" %>
-</div>
+    <div class="field form-group row mt-5">
+      <%= f.email_field :email, placeholder: 'Email', autofocus: true %>
+    </div>
+
+    <div class="actions modal-actions">
+      <%= f.submit "Send password update link", class: "btn-submit" %>
+      <%= link_to "Cancel", "/admin/login",  class: "btn-cancel" %>
+    </div>
+  <% end # form %>
 </div>

--- a/app/views/active_admin/devise/sessions/new.html.erb
+++ b/app/views/active_admin/devise/sessions/new.html.erb
@@ -1,5 +1,5 @@
 <div class="login-content pt-5">
-  <h2>Log in</h2>
+  <div class="logo">Log in</div>
   <div class="oauth-group">
 
     <%= link_to omniauth_authorize_path(:person, :facebook, auth_action: 'login'),

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -26,9 +26,7 @@ en:
       password_change:
         subject: "Password Changed"
     omniauth_callbacks:
-      failure: We're sorry, we were not able to log you in with %{kind}. Please use your
-               email address and Affinity password instead. If you have any problems,
-               contact us at info@affinity.works.
+      failure: Oops! Unable to login with %{kind}. Maybe you signed up for Affinity with an email that is not tied to your %{kind} account? Contact info@affinity.works if problems persist.
       success: "Successfully authenticated from %{kind} account."
     passwords:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."


### PR DESCRIPTION
resolves #679 
______________________________

# Functionality
* in all cases that a user tries to login with email not in system:
  * display error message styled like other error messages on site
  * suggest that user might be using email different than signup email
  * suggest contacting support if problems persist
* for oauth: display error message immediately on login page
* for email: display error on password reset page after trying to
  lookup email for password reset flow

# Implementation Notes
* add styling for oauth errors
* add `app/helpers/devise_helper.rb` to override standard behavior as
  suggested here: https://github.com/plataformatec/devise/wiki/Override-devise_error_messages!-for-views

# Screenshots

**error message in email flow:**
![wrong-email-error-msg](https://user-images.githubusercontent.com/6032844/40444291-f4262d92-5e96-11e8-9fc8-2908b4922645.png)

**error message in facebook flow:**
![error-wrong-fb-email](https://user-images.githubusercontent.com/6032844/40444298-fbf87df4-5e96-11e8-8bbd-c196608875a9.png)

**error message in google flow:**
![error-wrong-google-email](https://user-images.githubusercontent.com/6032844/40444308-044cba74-5e97-11e8-9491-b3662f4edc75.png)

# QA Instructions

## SETUP: 
1. Login to both Facebook and Gmail with testy@affinity.works
2. In the console, use the class method `Person.find_by_email("testy@affinity.works")` to ensure that no user with that email already exists

## QA:

### A. Testing OAuth paths

Repeat the below steps once for Google and once for Facebook:
1. go to `/admin/login`
2. click "Login with (Google or Facebook)"
3. verify that you see the error message in the screenshots

### B. Testing Email paths

1. go to `/admin/login`
2. click "Forgot your password?"
3. enter "aaaa@bbbbbb.cccc" into the "Email" field and hit <ENTER>
4. verify that you see the error message pictured in the screenshots


